### PR TITLE
AUS-3368: CSW search by keyword with bbox select doesn't work

### DIFF
--- a/project/src/app/menupanel/cataloguesearch/cataloguesearch.service.ts
+++ b/project/src/app/menupanel/cataloguesearch/cataloguesearch.service.ts
@@ -92,9 +92,6 @@ export class CataloguesearchService {
     if (param.west) {
       httpParams = httpParams.append('value', param.west);
     }
-    if (param.west) {
-      httpParams = httpParams.append('value', param.west);
-    }
     if (param.keywords) {
       httpParams = httpParams.append('value', param.keywords);
     }


### PR DESCRIPTION
Bbox west param was specified twice and overwrote the keyword value.