### PR TITLE
Fix split z-indices issue

### DIFF
--- a/project/src/app/cesium-map/csmap.component.css
+++ b/project/src/app/cesium-map/csmap.component.css
@@ -12,7 +12,6 @@
     background-color: rgba(17,216,66,0.8);
 }
 
-
 .editor-box {
     position: fixed;
     top: 100px;
@@ -26,10 +25,10 @@
     position: absolute;
     left: 50%;
     top: 0px;
-    background-color: #222;
+    background-color: #282572;
     width: 5px;
     height: 100%;
-    z-index: 9999;
+    z-index: 1;
 }
 #mapSlider:hover {
     cursor: ew-resize;
@@ -38,9 +37,24 @@
     left: -10px;
     width: 25px;
     height: 25px;
-    background: #222;
+    background: #282572;
     border-radius: 100px;
     position: relative;
     top: 50%;
     transform: translateY(-50%);
+}
+
+.slider-grabber-inner {
+    left: 5px;
+    width: 15px;
+    height: 15px;
+    background: #59c2aa;
+    border-radius: 90px;
+    position: relative;
+    top: 50%;
+    transform: translateY(-50%);
+}
+
+::ng-deep .cesium-viewer-toolbar {
+    z-index: 10;
 }

--- a/project/src/app/cesium-map/csmap.component.ts
+++ b/project/src/app/cesium-map/csmap.component.ts
@@ -17,7 +17,9 @@ import { Cartesian3, MapMode2D, Math, ScreenSpaceEventHandler, SceneMode, Screen
           <app-cs-map-split (toggleEvent)="toggleShowMapSplit()"></app-cs-map-split>
           <app-cs-clipboard class="btn-group float-right mb-3"></app-cs-clipboard>
           <div #mapSlider id="mapSlider" *ngIf="getSplitMapShown()">
-            <div class="slider-grabber"></div>
+            <div class="slider-grabber">
+              <div class="slider-grabber-inner"></div>
+            </div>
           </div>
       </ac-map>
     </div>

--- a/project/src/app/cesium-map/csmap.split.component.scss
+++ b/project/src/app/cesium-map/csmap.split.component.scss
@@ -3,6 +3,6 @@
     position: absolute;
     right: 83px;
     top: 5px;
-    z-index: 9999;
+    z-index: 10;
     font-size: 20px;
 }

--- a/project/src/app/menupanel/layerpanel/layerpanel.component.html
+++ b/project/src/app/menupanel/layerpanel/layerpanel.component.html
@@ -48,7 +48,7 @@
 							</div>
 							<div *ngIf="uiLayerModels[layer.id].statusMap.renderStarted || uiLayerModels[layer.id].statusMap.renderComplete" class="opacity-slider-panel d-flex" (click)="$event.stopPropagation()">
 								<div class="opacity-label">Opacity {{ uiLayerModels[layer.id].opacity }}%&nbsp;</div>
-								<mat-slider [min]="0" [max]="100" class="opacity-slider flex-grow-1" [(ngModel)]="uiLayerModels[layer.id].opacity" (input)="layerOpacityChange($event, layer)"></mat-slider>
+								<mat-slider [min]="0" [max]="100" class="flex-grow-1" [(ngModel)]="uiLayerModels[layer.id].opacity" (input)="layerOpacityChange($event, layer)"></mat-slider>
 							</div>
 							<div class="split-panel" *ngIf="getSplitMapShown() && (uiLayerModels[layer.id].statusMap.renderStarted || uiLayerModels[layer.id].statusMap.renderComplete)" (click)="$event.stopPropagation()">
 								Split Direction&nbsp;

--- a/project/src/app/menupanel/menupanel.scss
+++ b/project/src/app/menupanel/menupanel.scss
@@ -271,14 +271,18 @@ input + div.input-group-append  > button {
     .opacity-label {
         width: 80px;
     }
-    .opacity-slider {
-        ::ng-deep {
-            .mat-slider-thumb {
-                background-color: white;
-            }
-            .mat-slider-track-background {
-                background-color: white;
-            }
+    ::ng-deep {
+        .mat-slider {
+            height: 30px;
+        }
+        .mat-slider-horizontal .mat-slider-wrapper {
+            top: 15px;
+        }
+        .mat-slider-thumb {
+            background-color: white;
+        }
+        .mat-slider-track-background {
+            background-color: white;
         }
     }
 }


### PR DESCRIPTION
Adjust z-indices to prevent split panel bar from appearing on top of other components (Cesium widget toolbar, the custom widget split, NVCL dialogs etc).

Adjusted split colouring for slightly better visibility against imagery background.

Jira:  https://jira.csiro.au/browse/AUS-3575