### PR TITLE
AUS-3581 Fix and restyle truncated polygon clipboard

### DIFF
--- a/project/src/app/cesium-map/csmap.clipboard.component.css
+++ b/project/src/app/cesium-map/csmap.clipboard.component.css
@@ -1,0 +1,32 @@
+.editor-box {
+    position: fixed;
+    top: 100px;
+    right: 10px;
+    width:205px;
+    height:115px;
+    z-index: 100;
+    padding:0px;
+    background-color:#59c2aa;
+    opacity: 0.9;
+}
+
+/* Remove gap between buttons and selected polygon bbox name */
+.table {
+    margin-bottom: 0rem;
+}
+
+/* Remove default white underline */
+.table td {
+    border-top: none;
+}
+
+button:hover, button:focus  {
+    background-color: white;
+    opacity:  0.7;
+}
+
+/* Remove default blue shadow around buttons in 'focus' state */
+.btn:focus {
+    box-shadow: none;
+}
+

--- a/project/src/app/cesium-map/csmap.clipboard.component.html
+++ b/project/src/app/cesium-map/csmap.clipboard.component.html
@@ -1,19 +1,20 @@
 <polygons-editor></polygons-editor>
 
-<div *ngIf="bShowClipboard" class="container-fluid rounded editor-box" role="group"  style="padding:0px; background-color:#7aa5c5 ; color: #ffffff;">
+<div *ngIf="bShowClipboard" class="container-fluid rounded editor-box" role="group">
 		<small style="margin-left:10px">  Polygon Filter Clipboard:</small>
-		<table class="table table-inverse">
+		<table class="table">
 			<tbody>
-				<tr *ngIf="polygonBBox">
-					<td class="content-break-word">{{polygonBBox.name}}</td>
+				<tr>
+					<td *ngIf="polygonBBox" class="content-break-word">{{polygonBBox.name}}</td>
+					<td *ngIf="!polygonBBox">&nbsp;</td> <!-- Ensures buttons don't move up when user hits 'Clear' -->
 				</tr>
 			</tbody>
 		</table>
 	<div class="btn-toolbar " role="toolbar">
 	<div class="btn-group mr-2" role="group">			
-		<button (click)='clearClipboard()' type="button" class="btn btn-sm btn-inverse active"><i class="fa fa-times-circle" aria-hidden="true"></i>Clear</button>
-		<button (click)='drawPolygon()' type="button" [ngClass]="{'btn-inverse': !isDrawingPolygon, 'btn-active': isDrawingPolygon}" class="btn btn-sm btn-inverse active"><i class="fa fa-edit" aria-hidden="true"></i>Draw</button>
-		<button (click)='toggleFilterLayers()' type="button" [ngClass]="{'btn-inverse': !isFilterLayerShown, 'btn-active': isFilterLayerShown}" class="btn btn-sm btn-inverse active"><i class="fa fa-mouse-pointer" aria-hidden="true"></i>Select</button>
+		<button (click)='clearClipboard()' type="button" class="btn btn-sm btn-inverse active"><i class="fa fa-lg fa-times-circle" aria-hidden="true"></i>Clear</button>
+		<button (click)='drawPolygon()' type="button" [ngClass]="{'btn-inverse': !isDrawingPolygon, 'btn-active': isDrawingPolygon}" class="btn btn-sm btn-inverse active"><i class="fa fa-lg fa-edit" aria-hidden="true"></i>Draw</button>
+		<button (click)='toggleFilterLayers()' type="button" [ngClass]="{'btn-inverse': !isFilterLayerShown, 'btn-active': isFilterLayerShown}" class="btn btn-sm btn-inverse active"><i class="fa fa-lg fa-mouse-pointer" aria-hidden="true"></i>Select</button>
 		</div>
 	</div>
 </div>

--- a/project/src/app/cesium-map/csmap.clipboard.component.ts
+++ b/project/src/app/cesium-map/csmap.clipboard.component.ts
@@ -1,12 +1,10 @@
 import { CsClipboardService, Polygon } from '@auscope/portal-core-ui';
 import { Component, OnInit } from '@angular/core';
 
-// TODO: Convert to cesium
-
 @Component({
   selector: 'app-cs-clipboard',
   templateUrl: './csmap.clipboard.component.html',
-  styleUrls: ['./csmap.component.css'],
+  styleUrls: ['./csmap.clipboard.component.css'],
 })
 
 export class CsMapClipboardComponent implements OnInit {

--- a/project/src/app/cesium-map/csmap.component.css
+++ b/project/src/app/cesium-map/csmap.component.css
@@ -2,25 +2,6 @@
     z-index: 2;
 }
 
-/* Filter Clipboard */
-.card .card-body .btn {
-    background-color: rgba(49,197,86,0.5);
-    margin-right: 3px;
-    margin-left: 3px;
-}
-.card .card-body .btn-active {
-    background-color: rgba(17,216,66,0.8);
-}
-
-.editor-box {
-    position: fixed;
-    top: 100px;
-    right: 10px;
-    width:205px;
-    height:110px;
-    z-index: 100;
-}
-
 #mapSlider {
     position: absolute;
     left: 50%;


### PR DESCRIPTION
Make icons larger
Make all text the same black colour
Ensure that the buttons on the clipboard do not move up and down when a polygon name is added or removed
Use the AuScope dark jade colour as a background
Clipboard uses its own CSS file to ensure there are no conflicts with other components