### PR TITLE
AUS-3577 Layer loading bar not resetting

### DIFF
--- a/project/src/app/menupanel/layerpanel/layerpanel.component.ts
+++ b/project/src/app/menupanel/layerpanel/layerpanel.component.ts
@@ -240,6 +240,9 @@ export class LayerPanelComponent implements OnInit {
     public removeLayer(layer: LayerModel) {
       this.getUILayerModel(layer.id).opacity = 100;
       this.csMapService.removeLayer(layer);
+      setTimeout(() => {
+        this.renderStatusService.resetLayer(layer.id);
+      }, 100);
     }
 
     /**


### PR DESCRIPTION
Timeout required before resetting layer in RenderStatusService as updateComplete was being called after and messing with the percentage completion.