### PR TITLE
AUS-3601 Split map fix

### DIFF
--- a/project/src/app/cesium-map/csmap.component.ts
+++ b/project/src/app/cesium-map/csmap.component.ts
@@ -548,8 +548,9 @@ export class CsMapComponent implements AfterViewInit {
         }, 10);
 
     } else {
-      for (let l = 0; l < this.viewer.imageryLayers.length; l++) {
-        this.viewer.imageryLayers.get(l).splitDirection = ImagerySplitDirection.NONE;
+      let activeLayerKeys: string[] = Object.keys(this.csMapService.getLayerModelList());
+      for(const layer of activeLayerKeys) {
+        this.csMapService.setLayerSplitDirection(this.csMapService.getLayerModelList()[layer], ImagerySplitDirection.NONE);
       }
     }
   }

--- a/project/src/app/menupanel/activelayers/activelayerspanel.component.html
+++ b/project/src/app/menupanel/activelayers/activelayerspanel.component.html
@@ -11,11 +11,16 @@
             <div class="opacity-label">Opacity {{ getUILayerModel(layer.id).opacity }}%&nbsp;</div>
             <mat-slider [min]="0" [max]="100" class="opacity-slider flex-grow-1" [(ngModel)]="getUILayerModel(layer.id).opacity" (input)="layerOpacityChange($event, layer)"></mat-slider>
         </div>
-        <div class="split-panel" *ngIf="getShowLayerSplitButtons(layer)" (click)="$event.stopPropagation()">
+        <div class="split-panel" *ngIf="getShowSplitMapButtons(layer)" (click)="$event.stopPropagation()">
             Split Direction&nbsp;
-            <button [className]="getLayerSplitDirection(layer.id) == 'left' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'left')">Left</button>
-            <button [className]="getLayerSplitDirection(layer.id) == 'none' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'none')">Both</button>
-            <button [className]="getLayerSplitDirection(layer.id) == 'right' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'right')">Right</button>
+            <div *ngIf="getApplicableSplitLayer(layer)" class="split-button-panel">
+                <button [className]="getLayerSplitDirection(layer.id) == 'left' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'left')">Left</button>
+                <button [className]="getLayerSplitDirection(layer.id) == 'none' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'none')">Both</button>
+                <button [className]="getLayerSplitDirection(layer.id) == 'right' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'right')">Right</button>
+            </div>
+            <div *ngIf="!getApplicableSplitLayer(layer)" class="split-button-panel">
+                <button class="btn btn-split btn-primary" [disabled]="true">Layer not supported</button>
+            </div>
         </div>
     </div>
 </li>

--- a/project/src/app/menupanel/activelayers/activelayerspanel.component.html
+++ b/project/src/app/menupanel/activelayers/activelayerspanel.component.html
@@ -11,7 +11,7 @@
             <div class="opacity-label">Opacity {{ getUILayerModel(layer.id).opacity }}%&nbsp;</div>
             <mat-slider [min]="0" [max]="100" class="opacity-slider flex-grow-1" [(ngModel)]="getUILayerModel(layer.id).opacity" (input)="layerOpacityChange($event, layer)"></mat-slider>
         </div>
-        <div class="split-panel" *ngIf="getSplitMapShown()" (click)="$event.stopPropagation()">
+        <div class="split-panel" *ngIf="getShowLayerSplitButtons(layer)" (click)="$event.stopPropagation()">
             Split Direction&nbsp;
             <button [className]="getLayerSplitDirection(layer.id) == 'left' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'left')">Left</button>
             <button [className]="getLayerSplitDirection(layer.id) == 'none' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'none')">Both</button>

--- a/project/src/app/menupanel/activelayers/activelayerspanel.component.ts
+++ b/project/src/app/menupanel/activelayers/activelayerspanel.component.ts
@@ -65,10 +65,11 @@ export class ActiveLayersPanelComponent {
   }
 
   /**
-   * Split buttons will only be displayed if the split map is shown
+   * Split buttons will only be displayed if the split map is shown and the layer has started (or completed) rendering.
    */
-  public getSplitMapShown(): boolean {
-    return this.csMapService.getSplitMapShown();
+  public getShowSplitMapButtons(layer: LayerModel): boolean {
+    return this.csMapService.getSplitMapShown() &&
+           (this.getUILayerModel(layer.id).statusMap.getRenderStarted() || this.getUILayerModel(layer.id).statusMap.getRenderComplete());
   }
 
   /**
@@ -117,15 +118,12 @@ export class ActiveLayersPanelComponent {
   }
 
   /**
-     * For the given LayerModel, only show the split map buttons if the split map is shown,
-     * the layer has started (or completed) rendering, and the layer has a WMS resource
-     * 
-     * @param layer current LayerModel
-     */
-    public getShowLayerSplitButtons(layer: LayerModel): boolean {
-      return this.getSplitMapShown() &&
-             (this.getUILayerModel(layer.id).statusMap.getRenderStarted() || this.getUILayerModel(layer.id).statusMap.getRenderComplete()) &&
-             this.layerHandlerService.contains(layer, ResourceType.WMS);
-    }
+   * Only show the split map buttons if the layer has a WMS resource.
+   * 
+   * @param layer current LayerModel
+   */
+  public getApplicableSplitLayer(layer: LayerModel): boolean {
+    return this.layerHandlerService.contains(layer, ResourceType.WMS);
+  }
 
 }

--- a/project/src/app/menupanel/activelayers/activelayerspanel.component.ts
+++ b/project/src/app/menupanel/activelayers/activelayerspanel.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { CsClipboardService, CsMapService, LayerModel } from '@auscope/portal-core-ui';
+import { CsClipboardService, CsMapService, LayerHandlerService, LayerModel, ResourceType } from '@auscope/portal-core-ui';
 import { MatSliderChange } from '@angular/material/slider';
 import { ImagerySplitDirection } from 'cesium';
 import { UILayerModel } from '../common/model/ui/uilayer.model';
@@ -14,7 +14,8 @@ import { UILayerModelService } from 'app/services/ui/uilayer-model.service';
 
 export class ActiveLayersPanelComponent {
 
-  constructor(private csClipboardService: CsClipboardService, private csMapService: CsMapService, private uiLayerModelService: UILayerModelService) { }
+  constructor(private csClipboardService: CsClipboardService, private csMapService: CsMapService,
+    private uiLayerModelService: UILayerModelService, private layerHandlerService: LayerHandlerService) { }
 
   /**
    * Get active layers
@@ -114,5 +115,17 @@ export class ActiveLayersPanelComponent {
     }
     return splitDir;
   }
+
+  /**
+     * For the given LayerModel, only show the split map buttons if the split map is shown,
+     * the layer has started (or completed) rendering, and the layer has a WMS resource
+     * 
+     * @param layer current LayerModel
+     */
+    public getShowLayerSplitButtons(layer: LayerModel): boolean {
+      return this.getSplitMapShown() &&
+             (this.getUILayerModel(layer.id).statusMap.getRenderStarted() || this.getUILayerModel(layer.id).statusMap.getRenderComplete()) &&
+             this.layerHandlerService.contains(layer, ResourceType.WMS);
+    }
 
 }

--- a/project/src/app/menupanel/layerpanel/layerpanel.component.html
+++ b/project/src/app/menupanel/layerpanel/layerpanel.component.html
@@ -49,11 +49,16 @@
 							<div class="opacity-label">Opacity {{ getUILayerModel(layer.id).opacity }}%&nbsp;</div>
 							<mat-slider [min]="0" [max]="100" class="opacity-slider flex-grow-1" [(ngModel)]="getUILayerModel(layer.id).opacity" (input)="layerOpacityChange($event, layer)"></mat-slider>
 						</div>
-						<div class="split-panel" *ngIf="getShowLayerSplitButtons(layer)" (click)="$event.stopPropagation()">
+						<div class="split-panel" *ngIf="getShowSplitMapButtons(layer)" (click)="$event.stopPropagation()">
 							Split Direction&nbsp;
-							<button [className]="getLayerSplitDirection(layer.id) == 'left' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'left')">Left</button>
-							<button [className]="getLayerSplitDirection(layer.id) == 'none' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'none')">Both</button>
-							<button [className]="getLayerSplitDirection(layer.id) == 'right' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'right')">Right</button>
+							<div *ngIf="getApplicableSplitLayer(layer)" class="split-button-panel">
+								<button [className]="getLayerSplitDirection(layer.id) == 'left' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'left')">Left</button>
+								<button [className]="getLayerSplitDirection(layer.id) == 'none' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'none')">Both</button>
+								<button [className]="getLayerSplitDirection(layer.id) == 'right' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'right')">Right</button>
+							</div>
+							<div *ngIf="!getApplicableSplitLayer(layer)" class="split-button-panel">
+								<button class="btn btn-split btn-primary" [disabled]="true">Layer not supported</button>
+							</div>
 						</div>
 					</div>
 				</a>

--- a/project/src/app/menupanel/layerpanel/layerpanel.component.html
+++ b/project/src/app/menupanel/layerpanel/layerpanel.component.html
@@ -49,7 +49,7 @@
 							<div class="opacity-label">Opacity {{ getUILayerModel(layer.id).opacity }}%&nbsp;</div>
 							<mat-slider [min]="0" [max]="100" class="opacity-slider flex-grow-1" [(ngModel)]="getUILayerModel(layer.id).opacity" (input)="layerOpacityChange($event, layer)"></mat-slider>
 						</div>
-						<div class="split-panel" *ngIf="getSplitMapShown() && (getUILayerModel(layer.id).statusMap.getRenderStarted() || getUILayerModel(layer.id).statusMap.getRenderComplete())" (click)="$event.stopPropagation()">
+						<div class="split-panel" *ngIf="getShowLayerSplitButtons(layer)" (click)="$event.stopPropagation()">
 							Split Direction&nbsp;
 							<button [className]="getLayerSplitDirection(layer.id) == 'left' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'left')">Left</button>
 							<button [className]="getLayerSplitDirection(layer.id) == 'none' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'none')">Both</button>

--- a/project/src/app/menupanel/layerpanel/layerpanel.component.ts
+++ b/project/src/app/menupanel/layerpanel/layerpanel.component.ts
@@ -301,6 +301,18 @@ export class LayerPanelComponent implements OnInit {
     }
 
     /**
+     * For the given LayerModel, only show the split map buttons if the split map is shown,
+     * the layer has started (or completed) rendering, and the layer has a WMS resource
+     * 
+     * @param layer current LayerModel
+     */
+    public getShowLayerSplitButtons(layer: LayerModel): boolean {
+      return this.getSplitMapShown() &&
+             (this.getUILayerModel(layer.id).statusMap.getRenderStarted() || this.getUILayerModel(layer.id).statusMap.getRenderComplete()) &&
+             this.layerHandlerService.contains(layer, ResourceType.WMS);
+    }
+
+    /**
      * Returns true if any layer in a layer group is active 
      * "layerGroup" - an instance of this.layerGroups[key].value
      */

--- a/project/src/app/menupanel/layerpanel/layerpanel.component.ts
+++ b/project/src/app/menupanel/layerpanel/layerpanel.component.ts
@@ -253,10 +253,11 @@ export class LayerPanelComponent implements OnInit {
     }
 
     /**
-     * Split buttons will only be displayed if the split map is shown
+     * Split buttons will only be displayed if the split map is shown and the layer has started (or completed) rendering
      */
-    public getSplitMapShown(): boolean {
-      return this.csMapService.getSplitMapShown();
+    public getShowSplitMapButtons(layer: LayerModel): boolean {
+      return this.csMapService.getSplitMapShown() &&
+             (this.getUILayerModel(layer.id).statusMap.getRenderStarted() || this.getUILayerModel(layer.id).statusMap.getRenderComplete());
     }
 
     /**
@@ -301,15 +302,12 @@ export class LayerPanelComponent implements OnInit {
     }
 
     /**
-     * For the given LayerModel, only show the split map buttons if the split map is shown,
-     * the layer has started (or completed) rendering, and the layer has a WMS resource
+     * Only show the split map buttons if the layer has a WMS resource.
      * 
      * @param layer current LayerModel
      */
-    public getShowLayerSplitButtons(layer: LayerModel): boolean {
-      return this.getSplitMapShown() &&
-             (this.getUILayerModel(layer.id).statusMap.getRenderStarted() || this.getUILayerModel(layer.id).statusMap.getRenderComplete()) &&
-             this.layerHandlerService.contains(layer, ResourceType.WMS);
+    public getApplicableSplitLayer(layer: LayerModel): boolean {
+      return this.layerHandlerService.contains(layer, ResourceType.WMS);
     }
 
     /**

--- a/project/src/app/menupanel/menupanel.scss
+++ b/project/src/app/menupanel/menupanel.scss
@@ -298,6 +298,9 @@ input + div.input-group-append  > button {
 
 .split-panel {
     margin-bottom: 4px;
+    .split-button-panel {
+        display: contents;
+    }
 }
 
 .btn-split {


### PR DESCRIPTION
Only WMS layers have split direction buttons (when the split map is shown).

Removing a layer now properly resets its ImagerySplitDirection property.

Test:

* Add a WMS layer.
* Enable split map.
* Change the direction of the layer to Left or Right.
* Delete the layer.
* Re-add the layer, the split direction should have reset to Both (was originally remaining as Left or Right).
* To test only WMS layers prompting map split buttons, also try adding a CSW layer (e.g. Models). No buttons should appear.