### PR TITLE
AUS-3619 - Ignore empty filters

### DIFF
--- a/project/src/app/menupanel/common/filterpanel/filterpanel.component.ts
+++ b/project/src/app/menupanel/common/filterpanel/filterpanel.component.ts
@@ -98,6 +98,27 @@ export class FilterPanelComponent implements OnInit {
   }
 
   /**
+   * Test if a filter contains a value. This means non-null for all filters, with the added
+   * requirement for OPTIONAL.PROVIDER filters that at least one value in the list be true
+   * @param filter the filter to test
+   * @returns true if the filter contains a valid value
+   */
+  filterHasValue(filter: Object): boolean {
+    let hasValue = false;
+    if (filter['type'] === "OPTIONAL.PROVIDER") {
+      for (const provider in filter['value']) {
+        if (filter['value'][provider] === true) {
+          hasValue = true;
+          break;
+        }
+      }
+    } else if (filter['value'] !== null) {
+      hasValue = true;
+    }
+    return hasValue;
+  }
+
+  /**
    * Add layer to map
    * @param layer the layer to add to map
    */
@@ -112,6 +133,9 @@ export class FilterPanelComponent implements OnInit {
     const param = {
       optionalFilters: _.cloneDeep(this.optionalFilters)
     };
+
+    // Remove filters without values
+    param.optionalFilters = param.optionalFilters.filter(f => this.filterHasValue(f));
 
     for (const optFilter of param.optionalFilters) {
       if (optFilter['options']) {


### PR DESCRIPTION
Ignore filters that have no value, or in the case of the Provider filters where all values are false.
Note that there's still an issue with Provider filter not filtering properly but that's a separate issue currently being worked on.