### PR TITLE
AUS-3599-Add-Layers-Only-When-Can

### DIFF
--- a/project/src/app/menupanel/common/filterpanel/filterpanel.component.html
+++ b/project/src/app/menupanel/common/filterpanel/filterpanel.component.html
@@ -117,7 +117,11 @@
 	    <p *ngIf='layerStatus.isLayerDown(layer.id)' class='small text-danger'><i class="fa fa-warning text-warning"></i> One or more of the services used by this layer are reported to be experiencing issues at the moment. Click on the info panel for more information.</p>
 	    <div>
             <button *ngIf="analyticMap[layer.id]" type="button" class="btn btn-warning btn-sm" (click)="processLayerAnalytic(layer)"><i class="fa fa-bar-chart" aria-hidden="true"></i> Analytic</button>
-	    	<button type="button" class="btn btn-info btn-sm float-right" (click)="addLayer(layer)"><i class="fa fa-plus-circle" aria-hidden="true"></i> Add Layer</button>
+	    	<button type="button" *ngIf="isMapSupportedLayer(layer)" class="btn btn-info btn-sm float-right" (click)="addLayer(layer)"><i class="fa fa-plus-circle" aria-hidden="true"></i> Add Layer</button>
+			<div class="unsupported-layer-message" *ngIf="!isMapSupportedLayer(layer)">
+				<em class="fa fa-exclamation-triangle warning-icon"></em>
+				{{ getUnsupportedLayerMessage() }}
+			</div>
     	</div>
 
 

--- a/project/src/app/menupanel/common/filterpanel/filterpanel.component.scss
+++ b/project/src/app/menupanel/common/filterpanel/filterpanel.component.scss
@@ -7,3 +7,7 @@ div.red {
     margin-top: 4px;
     margin-left: 0px;
 }
+
+.warning-icon {
+    color: orange;
+}

--- a/project/src/app/menupanel/common/filterpanel/filterpanel.component.ts
+++ b/project/src/app/menupanel/common/filterpanel/filterpanel.component.ts
@@ -98,6 +98,25 @@ export class FilterPanelComponent implements OnInit {
   }
 
   /**
+   * Check to see if a layer is supported to be added to the map
+   * @param layer layer to check
+   * @returns true if supported layer, false otherwise
+   */
+  public isMapSupportedLayer(layer: LayerModel): boolean {
+    return this.csMapService.isMapSupportedLayer(layer);
+  }
+
+  /**
+   * String to display when a layer cannot be added to the map due to not
+   * containing a supported OnlineResource type.
+   */
+  public getUnsupportedLayerMessage(): string {
+    return "This layer is not supported. Only layers containing the " +
+           "following online resource types can be added to the map: " +
+           this.csMapService.getSupportedOnlineResourceTypes();
+  }
+
+  /**
    * Add layer to map
    * @param layer the layer to add to map
    */


### PR DESCRIPTION
Will only show the Add Layer button if the layer is supported, otherwise a brief message will explain why the layer can't be added and show the list of supporting layers.
Requires corresponding portal-core-ui-app pull request: https://github.com/AuScope/portal-core-ui-app/pull/29