### PR TITLE
Aus 3621 remove polygon filter context menu

### DIFF
--- a/project/src/app/cesium-map/csmap.clipboard.component.html
+++ b/project/src/app/cesium-map/csmap.clipboard.component.html
@@ -12,15 +12,17 @@
 		<table class="table">
 			<tbody>
 				<tr>
-					<td *ngIf="polygonBBox" class="content-break-word">{{polygonBBox.name}}</td>
-					<td *ngIf="!polygonBBox">&nbsp;No polygon</td>
+					<td *ngIf="!polygonBBox && !isDrawingPolygon">&nbsp;No polygon, click Draw to create one</td>
+					<td *ngIf="isDrawingPolygon">&nbsp;Click map to draw polygon, double-click to end</td>
+					<td *ngIf="!isDrawingPolygon && polygonBBox && !isFilterLayerShown" class="content-break-word">Polygon created, click Select to filter results</td>
+					<td *ngIf="!isDrawingPolygon && polygonBBox && isFilterLayerShown" class="content-break-word">Layers filtered, click Select to display all layers</td>
 				</tr>
 			</tbody>
 		</table>
 		<div class="btn-group mr-2 editor-button-group" role="group">
 			<button (click)='clearClipboard()' type="button" class="cesium-button cesium-toolbar-button editor-button"><em class="fa fa-lg fa-times-circle" aria-hidden="true"></em>Clear</button>
-			<button (click)='drawPolygon()' type="button" [ngClass]="{'btn-inverse': !isDrawingPolygon, 'btn-active': isDrawingPolygon}" class="cesium-button cesium-toolbar-button editor-button"><i class="fa fa-lg fa-edit" aria-hidden="true"></i>Draw</button>
-			<button (click)='toggleFilterLayers()' type="button" [ngClass]="{'btn-inverse': !isFilterLayerShown, 'btn-active': isFilterLayerShown}" class="cesium-button cesium-toolbar-button editor-button"><i class="fa fa-lg fa-mouse-pointer" aria-hidden="true"></i>Select</button>
+			<button (click)='drawPolygon()' type="button" [ngStyle]="{'background-color': isDrawingPolygon ? '#282572' : '#303336'}" class="cesium-button cesium-toolbar-button editor-button"><i class="fa fa-lg fa-edit" aria-hidden="true"></i>Draw</button>
+			<button (click)='toggleFilterLayers()' type="button" [ngStyle]="{'background-color': isFilterLayerShown ? '#282572' : '#303336'}" class="cesium-button cesium-toolbar-button editor-button"><i class="fa fa-lg fa-mouse-pointer" aria-hidden="true"></i>Select</button>
 		</div>
 	</div>
 </div>

--- a/project/src/app/cesium-map/csmap.clipboard.component.html
+++ b/project/src/app/cesium-map/csmap.clipboard.component.html
@@ -14,7 +14,7 @@
 				<tr>
 					<td *ngIf="!polygonBBox && !isDrawingPolygon">&nbsp;Click Draw to create polygon</td>
 					<td *ngIf="isDrawingPolygon">&nbsp;Click map to draw polygon, double-click to end</td>
-					<td *ngIf="!isDrawingPolygon && polygonBBox">Polygon created</td>
+					<td *ngIf="!isDrawingPolygon && polygonBBox">{{ polygonBBox.name }}</td>
 				</tr>
 			</tbody>
 		</table>

--- a/project/src/app/cesium-map/csmap.clipboard.component.html
+++ b/project/src/app/cesium-map/csmap.clipboard.component.html
@@ -12,17 +12,20 @@
 		<table class="table">
 			<tbody>
 				<tr>
-					<td *ngIf="!polygonBBox && !isDrawingPolygon">&nbsp;No polygon, click Draw to create one</td>
+					<td *ngIf="!polygonBBox && !isDrawingPolygon">&nbsp;Click Draw to create polygon</td>
 					<td *ngIf="isDrawingPolygon">&nbsp;Click map to draw polygon, double-click to end</td>
-					<td *ngIf="!isDrawingPolygon && polygonBBox && !isFilterLayerShown" class="content-break-word">Polygon created, click Select to filter results</td>
-					<td *ngIf="!isDrawingPolygon && polygonBBox && isFilterLayerShown" class="content-break-word">Layers filtered, click Select to display all layers</td>
+					<td *ngIf="!isDrawingPolygon && polygonBBox">Polygon created</td>
 				</tr>
 			</tbody>
 		</table>
 		<div class="btn-group mr-2 editor-button-group" role="group">
-			<button (click)='clearClipboard()' type="button" class="cesium-button cesium-toolbar-button editor-button"><em class="fa fa-lg fa-times-circle" aria-hidden="true"></em>Clear</button>
-			<button (click)='drawPolygon()' type="button" [ngStyle]="{'background-color': isDrawingPolygon ? '#282572' : '#303336'}" class="cesium-button cesium-toolbar-button editor-button"><i class="fa fa-lg fa-edit" aria-hidden="true"></i>Draw</button>
-			<button (click)='toggleFilterLayers()' type="button" [ngStyle]="{'background-color': isFilterLayerShown ? '#282572' : '#303336'}" class="cesium-button cesium-toolbar-button editor-button"><i class="fa fa-lg fa-mouse-pointer" aria-hidden="true"></i>Select</button>
+			<button (click)='clearClipboard()' type="button" title="Clear polygon" [disabled]="!polygonBBox || isDrawingPolygon" class="cesium-button cesium-toolbar-button editor-button"><em class="fa fa-lg fa-times-circle" aria-hidden="true"></em>Clear</button>
+			<button (click)='drawPolygon()' type="button" title="Draw polygon" [ngStyle]="{'background-color': isDrawingPolygon ? '#282572' : '#303336'}" class="cesium-button cesium-toolbar-button editor-button"><i class="fa fa-lg fa-edit" aria-hidden="true"></i>Draw</button>
+			<button (click)='toggleFilterLayers()' type="button" title="Toggle applicable layers" class="cesium-button cesium-toolbar-button editor-button">
+				<i *ngIf="!isFilterLayerShown" class="fa fa-lg fa-toggle-off" aria-hidden="true"></i>
+				<i *ngIf="isFilterLayerShown" class="fa fa-lg fa-toggle-on" aria-hidden="true"></i>
+				Toggle
+			</button>
 		</div>
 	</div>
 </div>

--- a/project/src/app/cesium-map/csmap.clipboard.component.scss
+++ b/project/src/app/cesium-map/csmap.clipboard.component.scss
@@ -1,3 +1,5 @@
+@import '../../app/globals';
+
 /* Editor toggle map buton */
 .editor-toggle-button {
     display: block;
@@ -31,6 +33,8 @@
 .table td {
     color: #edffff;
     border-top: none;
+    text-align: center;
+    word-break: break-word;
 }
 
 .editor-title {

--- a/project/src/app/cesium-map/csmap.clipboard.component.ts
+++ b/project/src/app/cesium-map/csmap.clipboard.component.ts
@@ -16,47 +16,45 @@ import { Component, OnInit } from '@angular/core';
     ]),
   ],
   templateUrl: './csmap.clipboard.component.html',
-  styleUrls: ['./csmap.clipboard.component.css'],
+  styleUrls: ['./csmap.clipboard.component.scss'],
 })
 
 export class CsMapClipboardComponent implements OnInit {
   buttonText = 'clipboard';
   polygonBBox: Polygon;
-  bShowClipboard: Boolean;
-  public isFilterLayerShown: Boolean;
+  bShowClipboard: boolean;
+  public isFilterLayerShown: boolean;
   public isDrawingPolygon: boolean;
   
-  constructor(private CsClipboardService: CsClipboardService) {
+  constructor(private csClipboardService: CsClipboardService) {
     this.polygonBBox = null;
     this.isFilterLayerShown = false;
-    this.isDrawingPolygon = false;
-    this.CsClipboardService.filterLayersBS.subscribe(filterLayerStatus => {
+    this.csClipboardService.filterLayersBS.subscribe(filterLayerStatus => {
       this.isFilterLayerShown = filterLayerStatus;
-    })
-
-    this.CsClipboardService.polygonsBS.subscribe(polygon => {
-        this.isDrawingPolygon = false;
-    })
+    });
+    this.csClipboardService.isDrawingPolygonBS.subscribe(drawingPolygon => {
+      this.isDrawingPolygon = drawingPolygon;
+    });
   }
 
   ngOnInit(): void {
-    this.CsClipboardService.clipboardBS.subscribe(
+    this.csClipboardService.clipboardBS.subscribe(
       (show) => {
         this.bShowClipboard = show;
     });
 
-    this.CsClipboardService.polygonsBS.subscribe(
+    this.csClipboardService.polygonsBS.subscribe(
       (polygonBBox) => {
         this.polygonBBox = polygonBBox;
     });
   }
 
   clearClipboard() {
-    this.CsClipboardService.clearClipboard();
+    this.csClipboardService.clearClipboard();
   }
 
   public toggleFilterLayers() {
-    this.CsClipboardService.toggleFilterLayers();
+    this.csClipboardService.toggleFilterLayers();
   }
 
   /**
@@ -64,8 +62,7 @@ export class CsMapClipboardComponent implements OnInit {
    *
    */
   public drawPolygon(): void {
-    this.isDrawingPolygon = true;
-    this.CsClipboardService.drawPolygon();
+    this.csClipboardService.drawPolygon();
   }
 
   getPolygonBBoxs(): String {
@@ -73,7 +70,7 @@ export class CsMapClipboardComponent implements OnInit {
   }
 
   toggleEditor() {
-    this.CsClipboardService.toggleClipboard();
+    this.csClipboardService.toggleClipboard();
   }
 
 }

--- a/project/src/app/cesium-map/csmap.clipboard.component.ts
+++ b/project/src/app/cesium-map/csmap.clipboard.component.ts
@@ -65,7 +65,7 @@ export class CsMapClipboardComponent implements OnInit {
     this.csClipboardService.drawPolygon();
   }
 
-  getPolygonBBoxs(): String {
+  getPolygonBBoxs(): string {
     return this.polygonBBox.coordinates;
   }
 

--- a/project/src/app/cesium-map/csmap.component.ts
+++ b/project/src/app/cesium-map/csmap.component.ts
@@ -301,7 +301,9 @@ export class CsMapComponent implements AfterViewInit {
       // VT: if it is a csw renderer layer, handling of the click is slightly different
       if (config.cswrenderer.includes(entity.layer.id) || CsCSWService.cswDiscoveryRendered.includes(entity.layer.id)) {
         this.setModalHTML(this.parseCSWtoHTML(entity.cswRecord), entity.cswRecord.name, entity, this.bsModalRef);
-      } else if (ref.customQuerierHandler[entity.layer.id]) {
+      }
+      // Note: customQuerierHandler property currently removed from ref.ts
+      else if (ref.customQuerierHandler[entity.layer.id]) {
           const handler = new ref.customQuerierHandler[entity.layer.id](entity);
           this.setModalHTML(handler.getHTML(entity), handler.getKey(entity), entity, this.bsModalRef);
       } else {       // VT: in a normal feature, yes we want to getfeatureinfo

--- a/project/src/app/menupanel/common/filterpanel/filterpanel.component.ts
+++ b/project/src/app/menupanel/common/filterpanel/filterpanel.component.ts
@@ -235,15 +235,13 @@ export class FilterPanelComponent implements OnInit {
   public onApplyClipboardBBox(): void {
     this.csClipboardService.polygonsBS.subscribe(polygon => {
       if (polygon !== null && this.bApplyClipboardBBox) {
-        this.csClipboardService.polygonsBS.subscribe(polygonBBoxs => {
-          if (!UtilitiesService.isEmpty(polygonBBoxs)) {
-            for (const optFilter of this.optionalFilters) {
-              if (optFilter['type'] === 'OPTIONAL.POLYGONBBOX') {
-                optFilter['value'] = polygonBBoxs.coordinates;
-              }
+        if (!UtilitiesService.isEmpty(polygon)) {
+          for (const optFilter of this.optionalFilters) {
+            if (optFilter['type'] === 'OPTIONAL.POLYGONBBOX') {
+              optFilter['value'] = polygon.coordinates;
             }
           }
-        });
+        }
       } else {
         for (const optFilter of this.optionalFilters) {
           if (optFilter['type'] === 'OPTIONAL.POLYGONBBOX') {

--- a/project/src/app/menupanel/common/filterpanel/filterpanel.component.ts
+++ b/project/src/app/menupanel/common/filterpanel/filterpanel.component.ts
@@ -43,7 +43,7 @@ export class FilterPanelComponent implements OnInit {
     private filterPanelService: FilterPanelService,
     private modalService: BsModalService,
     private manageStateService: ManageStateService,
-    private CsClipboardService: CsClipboardService,
+    private csClipboardService: CsClipboardService,
     private csWMSService: CsWMSService,
     public layerStatus: LayerStatusService
   ) {
@@ -191,7 +191,6 @@ export class FilterPanelComponent implements OnInit {
     }
   }
 
-
   /**
    * Get Filter for NvclAnalytical
    * @param layer the layer to add to map
@@ -228,29 +227,33 @@ export class FilterPanelComponent implements OnInit {
       alert('Unable to getNvclFilter');
     }
   }
+
   /**
    * Draw a polygon layer to map
    *
    */
   public onApplyClipboardBBox(): void {
-    if (this.bApplyClipboardBBox) {
-      this.CsClipboardService.polygonsBS.subscribe(polygonBBoxs => {
-        if (!UtilitiesService.isEmpty(polygonBBoxs)) {
-          for (const optFilter of this.optionalFilters) {
-            if (optFilter['type'] === 'OPTIONAL.POLYGONBBOX') {
-              optFilter['value'] = polygonBBoxs.coordinates;
+    this.csClipboardService.polygonsBS.subscribe(polygon => {
+      if (polygon !== null && this.bApplyClipboardBBox) {
+        this.csClipboardService.polygonsBS.subscribe(polygonBBoxs => {
+          if (!UtilitiesService.isEmpty(polygonBBoxs)) {
+            for (const optFilter of this.optionalFilters) {
+              if (optFilter['type'] === 'OPTIONAL.POLYGONBBOX') {
+                optFilter['value'] = polygonBBoxs.coordinates;
+              }
             }
           }
-        }
-      });
-    } else {
-      for (const optFilter of this.optionalFilters) {
-        if (optFilter['type'] === 'OPTIONAL.POLYGONBBOX') {
-          optFilter['value'] = null;
+        });
+      } else {
+        for (const optFilter of this.optionalFilters) {
+          if (optFilter['type'] === 'OPTIONAL.POLYGONBBOX') {
+            optFilter['value'] = null;
+          }
         }
       }
-    }
+    });
   }
+
   public getKey(options: Object): string {
     return UtilitiesService.getKey(options);
   }
@@ -302,7 +305,7 @@ export class FilterPanelComponent implements OnInit {
     }
 
     if (filter.type === 'OPTIONAL.POLYGONBBOX') {
-      this.CsClipboardService.toggleClipboard(true);
+      this.csClipboardService.toggleClipboard(true);
     }
     this.optionalFilters.push(filter);
   }

--- a/project/src/app/menupanel/layerpanel/layerpanel.component.html
+++ b/project/src/app/menupanel/layerpanel/layerpanel.component.html
@@ -1,4 +1,3 @@
-
 	<div class="form-group" class="search-layers">
 		<div class="input-group">
             <input type="text" class="form-control" placeholder="Enter search term here..." [(ngModel)]="searchText" [disabled]="searchMode">
@@ -22,6 +21,12 @@
                 </ul>
             </div>
         </div>
+	</div>
+	<div *ngIf="areLayersFiltered" class="filtered-layers">
+		<div>Showing layers compatible with Polygon Filter</div>
+		<button class="btn btn-info btn-sm" type="button" title="Show all layers" (click)="removeFilterLayers()">
+			Show All
+		</button>
 	</div>
 	<li *ngFor="let layerGroup of layerGroups | getKey" >
 		<a [hidden]="layerGroup.value.hide" (click)="layerGroup.value.loaded=layerGroup.value;layerGroup.value.expanded = !layerGroup.value.expanded;"

--- a/project/src/app/menupanel/layerpanel/layerpanel.component.html
+++ b/project/src/app/menupanel/layerpanel/layerpanel.component.html
@@ -28,12 +28,12 @@
 			Show All
 		</button>
 	</div>
-	<li *ngFor="let layerGroup of layerGroups | getKey" >
+	<li *ngFor="let layerGroup of layerGroups | keyvalue" >
 		<a [hidden]="layerGroup.value.hide" (click)="layerGroup.value.loaded=layerGroup.value;layerGroup.value.expanded = !layerGroup.value.expanded;"
 			[ngClass]="{'highlight': isLayerGroupVisible(layerGroup.value) , 'text-primary': isLayerGroupActive(layerGroup.value),
 				'font-weight-bold': isLayerGroupActive(layerGroup.value) ,'font-italic':isLayerGroupActive(layerGroup.value)}" >
 			{{layerGroup.key}}
-			<i class="fa fa-arrow-circle-down" [ngClass]="{'submenu-open-inline':isLayerGroupVisible(layerGroup.value), 'hidden':!isLayerGroupVisible(layerGroup.value) }" ></i>
+			<i class="fa fa-arrow-circle-down" [ngClass]="{'submenu-open-inline':isLayerGroupVisible(layerGroup.value), 'hidden':!isLayerGroupVisible(layerGroup.value) }"></i>
 		</a>
 		<ul *ngIf="layerGroup.value.loaded" [ngClass]="{'submenu-open-block':layerGroup.value.expanded, 'hidden':!layerGroup.value.expanded}">
 			<li *ngFor="let layer of layerGroup.value.loaded" [ngClass]="{'active': layer.expanded}">

--- a/project/src/app/menupanel/layerpanel/layerpanel.component.ts
+++ b/project/src/app/menupanel/layerpanel/layerpanel.component.ts
@@ -35,25 +35,32 @@ export class LayerPanelComponent implements OnInit {
   public selectTabPanel(layerId: string, panelType: string) {
     this.getUILayerModel(layerId).tabpanel.setPanelOpen(panelType);
   }
+
+  /**
+   * Check if a LayerModel contains a filter collection that has an optional filter of type "OPTIONAL.POLYGONBBOX"
+   * @param layer the LayerModel
+   * @returns true if a polygon filter is found, false otherwise
+   */
+  private layerHasPolygonFilter(layer: LayerModel): boolean {
+    return layer.filterCollection !== undefined && (layer.filterCollection.optionalFilters !== null &&
+      layer.filterCollection.optionalFilters.filter(f => f.type === 'OPTIONAL.POLYGONBBOX').length > 0);
+  }
   
   /**
-   * Filter layers based on polygon filter compatibility
+   * Filter layers based on polygon filter
    */
   public searchFilter() {
     for (const layerGroupKey in this.layerGroups) {
       this.layerGroups[layerGroupKey].hide = true;
       for (const layer of this.layerGroups[layerGroupKey]) {
-        // Look for layers with a filterCollection containing an optional filter of type 'OPTIONAL.POLYGONBBOX'
-        if (layer.filterCollection !== undefined && (layer.filterCollection.optionalFilters !== null &&
-            layer.filterCollection.optionalFilters.filter(f => f.type === 'OPTIONAL.POLYGONBBOX').length > 0)) {
+        layer.hide = true;
+        this.layerGroups[layerGroupKey].loaded = undefined;
+        // Only layers with a polygon filter
+        if (this.layerHasPolygonFilter(layer)) {
           layer.hide = false;
           this.layerGroups[layerGroupKey].hide = false;
-
           this.layerGroups[layerGroupKey].expanded = true;
           this.layerGroups[layerGroupKey].loaded = this.layerGroups[layerGroupKey];
-
-        } else {
-          layer.hide = true;
         }
       }
     }
@@ -68,17 +75,20 @@ export class LayerPanelComponent implements OnInit {
     } else {
       this.searchMode = true;
     }
-
     for (const layerGroupKey in this.layerGroups) {
       this.layerGroups[layerGroupKey].hide = true;
       for (const layer of this.layerGroups[layerGroupKey]) {
+        layer.hide = true;
+        this.layerGroups[layerGroupKey].loaded = undefined;
+        if (this.areLayersFiltered && !this.layerHasPolygonFilter(layer)) {
+          continue;
+        }
         if (layerGroupKey.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0
             || layer.description.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0
             || layer.name.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0) {
           layer.hide = false;
           this.layerGroups[layerGroupKey].hide = false;
-        } else {
-          layer.hide = true;
+          this.layerGroups[layerGroupKey].loaded = this.layerGroups[layerGroupKey];
         }
       }
     }
@@ -94,13 +104,17 @@ export class LayerPanelComponent implements OnInit {
     for (const layerGroupKey in this.layerGroups) {
       this.layerGroups[layerGroupKey].hide = true;
       for (const layer of this.layerGroups[layerGroupKey]) {
+        layer.hide = true;
+        layer.expanded = false;
+        this.layerGroups[layerGroupKey].loaded = undefined;
+        if (this.areLayersFiltered && !this.layerHasPolygonFilter(layer)) {
+          continue;
+        }
         if (this.getUILayerModel(layer.id).statusMap.getRenderStarted()) {
           layer.hide = false;
           this.layerGroups[layerGroupKey].hide = false;
           this.layerGroups[layerGroupKey].expanded = true;
-          layer.expanded = false;
-        } else {
-          layer.hide = true;
+          this.layerGroups[layerGroupKey].loaded = this.layerGroups[layerGroupKey];
           layer.expanded = false;
         }
       }
@@ -117,13 +131,17 @@ export class LayerPanelComponent implements OnInit {
     for (const layerGroupKey in this.layerGroups) {
       this.layerGroups[layerGroupKey].hide = true;
       for (const layer of this.layerGroups[layerGroupKey]) {
+        layer.hide = true;
+        layer.expanded = false;
+        this.layerGroups[layerGroupKey].loaded = undefined;
+        if (this.areLayersFiltered && !this.layerHasPolygonFilter(layer)) {
+          continue;
+        }
         if (this.layerHandlerService.contains(layer, ResourceType.WMS)) {
           layer.hide = false;
           this.layerGroups[layerGroupKey].hide = false;
           this.layerGroups[layerGroupKey].expanded = true;
-          layer.expanded = false;
-        } else {
-          layer.hide = true;
+          this.layerGroups[layerGroupKey].loaded = this.layerGroups[layerGroupKey];
           layer.expanded = false;
         }
       }
@@ -140,13 +158,17 @@ export class LayerPanelComponent implements OnInit {
     for (const layerGroupKey in this.layerGroups) {
       this.layerGroups[layerGroupKey].hide = true;
       for (const layer of this.layerGroups[layerGroupKey]) {
+        layer.hide = true;
+        layer.expanded = false;
+        this.layerGroups[layerGroupKey].loaded = undefined;
+        if (this.areLayersFiltered && !this.layerHasPolygonFilter(layer)) {
+          continue;
+        }
         if (this.layerHandlerService.contains(layer, ResourceType.WFS)) {
           layer.hide = false;
           this.layerGroups[layerGroupKey].hide = false;
           this.layerGroups[layerGroupKey].expanded = true;
-          layer.expanded = false;
-        } else {
-          layer.hide = true;
+          this.layerGroups[layerGroupKey].loaded = this.layerGroups[layerGroupKey];
           layer.expanded = false;
         }
       }

--- a/project/src/app/menupanel/layerpanel/layerpanel.component.ts
+++ b/project/src/app/menupanel/layerpanel/layerpanel.component.ts
@@ -1,10 +1,9 @@
 import { Component, OnInit, Output, EventEmitter } from '@angular/core';
 import { NgbdModalStatusReportComponent } from '../../toppanel/renderstatus/renderstatus.component';
-import { CsClipboardService, CsMapService, KeysPipe, LayerHandlerService, LayerModel, ManageStateService, RenderStatusService, ResourceType, UtilitiesService } from '@auscope/portal-core-ui';
+import { CsClipboardService, CsMapService, LayerHandlerService, LayerModel, ManageStateService, RenderStatusService, ResourceType, UtilitiesService } from '@auscope/portal-core-ui';
 import { UILayerModel } from '../common/model/ui/uilayer.model';
 import { UILayerModelService } from 'app/services/ui/uilayer-model.service';
 import { BsModalService, BsModalRef } from 'ngx-bootstrap/modal';
-import { config } from '../../../environments/config';
 import { MatSliderChange } from '@angular/material/slider';
 import { ImagerySplitDirection } from 'cesium';
 
@@ -49,6 +48,10 @@ export class LayerPanelComponent implements OnInit {
             layer.filterCollection.optionalFilters.filter(f => f.type === 'OPTIONAL.POLYGONBBOX').length > 0)) {
           layer.hide = false;
           this.layerGroups[layerGroupKey].hide = false;
+
+          this.layerGroups[layerGroupKey].expanded = true;
+          this.layerGroups[layerGroupKey].loaded = this.layerGroups[layerGroupKey];
+
         } else {
           layer.hide = true;
         }
@@ -70,8 +73,8 @@ export class LayerPanelComponent implements OnInit {
       this.layerGroups[layerGroupKey].hide = true;
       for (const layer of this.layerGroups[layerGroupKey]) {
         if (layerGroupKey.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0
-          || layer.description.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0
-          || layer.name.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0) {
+            || layer.description.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0
+            || layer.name.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0) {
           layer.hide = false;
           this.layerGroups[layerGroupKey].hide = false;
         } else {
@@ -126,7 +129,6 @@ export class LayerPanelComponent implements OnInit {
       }
     }
   }
-
 
   /**
    * search through the layers and filter out based on keyword

--- a/project/src/app/menupanel/layerpanel/layerpanel.component.ts
+++ b/project/src/app/menupanel/layerpanel/layerpanel.component.ts
@@ -1,19 +1,11 @@
 import { Component, OnInit, Output, EventEmitter } from '@angular/core';
-import { LayerHandlerService } from '@auscope/portal-core-ui';
 import { NgbdModalStatusReportComponent } from '../../toppanel/renderstatus/renderstatus.component';
-import { LayerModel } from '@auscope/portal-core-ui';
-import { CsMapService } from '@auscope/portal-core-ui';
-import { CsClipboardService } from '@auscope/portal-core-ui';
+import { CsClipboardService, CsMapService, KeysPipe, LayerHandlerService, LayerModel, ManageStateService, RenderStatusService, ResourceType, UtilitiesService } from '@auscope/portal-core-ui';
 import { UILayerModel } from '../common/model/ui/uilayer.model';
 import { UILayerModelService } from 'app/services/ui/uilayer-model.service';
 import { BsModalService, BsModalRef } from 'ngx-bootstrap/modal';
-import { RenderStatusService } from '@auscope/portal-core-ui';
-import { ManageStateService } from '@auscope/portal-core-ui';
-import { UtilitiesService } from '@auscope/portal-core-ui';
-import {config} from '../../../environments/config';
+import { config } from '../../../environments/config';
 import { MatSliderChange } from '@angular/material/slider';
-import { KeysPipe } from '@auscope/portal-core-ui'; // Necessary for 'getKey' pipe in "layerpanel.component.html"
-import { ResourceType } from '@auscope/portal-core-ui';
 import { ImagerySplitDirection } from 'cesium';
 
 
@@ -29,300 +21,313 @@ export class LayerPanelComponent implements OnInit {
   @Output() expanded: EventEmitter<any> = new EventEmitter();
   searchText: string
   searchMode: boolean;
+  areLayersFiltered: boolean;
 
   constructor(private layerHandlerService: LayerHandlerService, private renderStatusService: RenderStatusService,
-    private modalService: BsModalService, private csMapService: CsMapService,
-    private manageStateService: ManageStateService, private CsClipboardService: CsClipboardService,
-    private uiLayerModelService: UILayerModelService) {
+      private modalService: BsModalService, private csMapService: CsMapService,
+      private manageStateService: ManageStateService, private CsClipboardService: CsClipboardService,
+      private uiLayerModelService: UILayerModelService) {
     this.searchMode = false;
-   }
+    this.CsClipboardService.filterLayersBS.subscribe(filterLayers => {
+      this.areLayersFiltered = filterLayers;
+    });
+  }
 
-    public selectTabPanel(layerId: string, panelType: string) {
-      this.getUILayerModel(layerId).tabpanel.setPanelOpen(panelType);
-    }
-    
-    /**
-     * search through the layers and filter out based on keyword
-     */
-    public searchFilter() {
-      const reg = new RegExp(config.clipboard.supportedLayersRegName, 'gi');
-      for (const layerGroupKey in this.layerGroups) {
-        this.layerGroups[layerGroupKey].hide = true;
-        for (const layer of this.layerGroups[layerGroupKey]) {
-          if (layer.name.search(reg) >= 0) {
-            layer.hide = false;
-            this.layerGroups[layerGroupKey].hide = false;
-          } else {
-            layer.hide = true;
-          }
+  public selectTabPanel(layerId: string, panelType: string) {
+    this.getUILayerModel(layerId).tabpanel.setPanelOpen(panelType);
+  }
+  
+  /**
+   * Filter layers based on polygon filter compatibility
+   */
+  public searchFilter() {
+    for (const layerGroupKey in this.layerGroups) {
+      this.layerGroups[layerGroupKey].hide = true;
+      for (const layer of this.layerGroups[layerGroupKey]) {
+        // Look for layers with a filterCollection containing an optional filter of type 'OPTIONAL.POLYGONBBOX'
+        if (layer.filterCollection !== undefined && (layer.filterCollection.optionalFilters !== null &&
+            layer.filterCollection.optionalFilters.filter(f => f.type === 'OPTIONAL.POLYGONBBOX').length > 0)) {
+          layer.hide = false;
+          this.layerGroups[layerGroupKey].hide = false;
+        } else {
+          layer.hide = true;
         }
       }
     }
-    /**
-     * search through the layers and filter out based on keyword
-     */
-    public search() {
-      if (this.searchText.trim() === '') {
-        this.searchMode = false;
-      } else {
-        this.searchMode = true;
-      }
+  }
 
-      for (const layerGroupKey in this.layerGroups) {
-        this.layerGroups[layerGroupKey].hide = true;
-        for (const layer of this.layerGroups[layerGroupKey]) {
-          if (layerGroupKey.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0
-            || layer.description.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0
-            || layer.name.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0) {
-            layer.hide = false;
-            this.layerGroups[layerGroupKey].hide = false;
-          } else {
-            layer.hide = true;
-          }
-        }
-      }
-    }
-
-    /**
-     * search through the layers and filter out based on keyword
-     */
-    public searchActive() {
-      this.searchText = 'Active Layer';
+  /**
+   * search through the layers and filter out based on keyword
+   */
+  public search() {
+    if (this.searchText.trim() === '') {
+      this.searchMode = false;
+    } else {
       this.searchMode = true;
+    }
 
-      for (const layerGroupKey in this.layerGroups) {
-        this.layerGroups[layerGroupKey].hide = true;
-        for (const layer of this.layerGroups[layerGroupKey]) {
-          if (this.getUILayerModel(layer.id).statusMap.getRenderStarted()) {
-            layer.hide = false;
-            this.layerGroups[layerGroupKey].hide = false;
-            this.layerGroups[layerGroupKey].expanded = true;
-            layer.expanded = false;
-          } else {
-            layer.hide = true;
-            layer.expanded = false;
-          }
+    for (const layerGroupKey in this.layerGroups) {
+      this.layerGroups[layerGroupKey].hide = true;
+      for (const layer of this.layerGroups[layerGroupKey]) {
+        if (layerGroupKey.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0
+          || layer.description.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0
+          || layer.name.toLowerCase().indexOf(this.searchText.toLowerCase()) >= 0) {
+          layer.hide = false;
+          this.layerGroups[layerGroupKey].hide = false;
+        } else {
+          layer.hide = true;
         }
       }
     }
+  }
 
-    /**
-     * search through the layers and filter out based on keyword
-     */
-    public searchImage() {
-      this.searchText = 'Image Layer';
-      this.searchMode = true;
+  /**
+   * search through the layers and filter out based on keyword
+   */
+  public searchActive() {
+    this.searchText = 'Active Layer';
+    this.searchMode = true;
 
-      for (const layerGroupKey in this.layerGroups) {
-        this.layerGroups[layerGroupKey].hide = true;
-        for (const layer of this.layerGroups[layerGroupKey]) {
-          if (this.layerHandlerService.contains(layer, ResourceType.WMS)) {
-            layer.hide = false;
-            this.layerGroups[layerGroupKey].hide = false;
-            this.layerGroups[layerGroupKey].expanded = true;
-            layer.expanded = false;
-          } else {
-            layer.hide = true;
-            layer.expanded = false;
-          }
+    for (const layerGroupKey in this.layerGroups) {
+      this.layerGroups[layerGroupKey].hide = true;
+      for (const layer of this.layerGroups[layerGroupKey]) {
+        if (this.getUILayerModel(layer.id).statusMap.getRenderStarted()) {
+          layer.hide = false;
+          this.layerGroups[layerGroupKey].hide = false;
+          this.layerGroups[layerGroupKey].expanded = true;
+          layer.expanded = false;
+        } else {
+          layer.hide = true;
+          layer.expanded = false;
         }
       }
     }
+  }
 
+  /**
+   * search through the layers and filter out based on keyword
+   */
+  public searchImage() {
+    this.searchText = 'Image Layer';
+    this.searchMode = true;
 
-    /**
-     * search through the layers and filter out based on keyword
-     */
-    public searchData() {
-      this.searchText = 'Data Layer';
-      this.searchMode = true;
-
-      for (const layerGroupKey in this.layerGroups) {
-        this.layerGroups[layerGroupKey].hide = true;
-        for (const layer of this.layerGroups[layerGroupKey]) {
-          if (this.layerHandlerService.contains(layer, ResourceType.WFS)) {
-            layer.hide = false;
-            this.layerGroups[layerGroupKey].hide = false;
-            this.layerGroups[layerGroupKey].expanded = true;
-            layer.expanded = false;
-          } else {
-            layer.hide = true;
-            layer.expanded = false;
-          }
+    for (const layerGroupKey in this.layerGroups) {
+      this.layerGroups[layerGroupKey].hide = true;
+      for (const layer of this.layerGroups[layerGroupKey]) {
+        if (this.layerHandlerService.contains(layer, ResourceType.WMS)) {
+          layer.hide = false;
+          this.layerGroups[layerGroupKey].hide = false;
+          this.layerGroups[layerGroupKey].expanded = true;
+          layer.expanded = false;
+        } else {
+          layer.hide = true;
+          layer.expanded = false;
         }
       }
     }
+  }
 
-    /**
-     * Returns true if any layer in a layer group is visible in the sidebar
-     * "layerGroup" - an instance of this.layerGroups[key].value
-     */
-    public isLayerGroupVisible(layerGroupValue): boolean {
-        if (layerGroupValue.expanded && layerGroupValue.loaded) {
-            for (const layer of layerGroupValue.loaded) {
-                if (layer.hide === false) {
-                    return true;
-                }
-            }
+
+  /**
+   * search through the layers and filter out based on keyword
+   */
+  public searchData() {
+    this.searchText = 'Data Layer';
+    this.searchMode = true;
+
+    for (const layerGroupKey in this.layerGroups) {
+      this.layerGroups[layerGroupKey].hide = true;
+      for (const layer of this.layerGroups[layerGroupKey]) {
+        if (this.layerHandlerService.contains(layer, ResourceType.WFS)) {
+          layer.hide = false;
+          this.layerGroups[layerGroupKey].hide = false;
+          this.layerGroups[layerGroupKey].expanded = true;
+          layer.expanded = false;
+        } else {
+          layer.hide = true;
+          layer.expanded = false;
         }
-        return false;
+      }
     }
+  }
 
-    /**
-     * Clear the search result
-     */
-    public clearSearch() {
-      setTimeout(() => {
-        this.searchMode = false;
-        this.searchText = '';
-        this.search();
-      }, 0);
-    }
-
-    public ngOnInit() {
-        const nvclanid = UtilitiesService.getUrlParameterByName('nvclanid');
-        const state = UtilitiesService.getUrlParameterByName('state');
-        const me = this;
-        this.manageStateService.getUnCompressedString(state, function(result) {
-          const layerStateObj = JSON.parse(result);
-          if (!UtilitiesService.isEmpty(layerStateObj)) {
-            me.manageStateService.resumeMapState(layerStateObj.map);
-          }
-          me.layerHandlerService.getLayerRecord().subscribe(
-            response => {
-              me.layerGroups = response;
-              for (const key in me.layerGroups) {
-                for (let i = 0; i < me.layerGroups[key].length; i++) {
-                  me.layerGroups[key][i].csLayers = [];
-                  const uiLayerModel = new UILayerModel(me.layerGroups[key][i].id, me.renderStatusService.getStatusBSubject(me.layerGroups[key][i]));
-                  // VT: permanent link
-                  if (layerStateObj && layerStateObj[uiLayerModel.id]) {
-                    me.layerGroups[key].expanded = true;
-                    me.layerGroups[key].loaded = me.layerGroups[key];
-                    me.layerGroups[key][i].expanded = true;
-                    me.layerGroups[key][i].filterCollection.hiddenParams = layerStateObj[uiLayerModel.id].filterCollection.hiddenParams
-                    me.layerGroups[key][i].filterCollection.mandatoryFilters = layerStateObj[uiLayerModel.id].filterCollection.mandatoryFilters
-                  }
-                  // LJ: nvclAnalyticalJob link
-                  if (nvclanid && uiLayerModel.id === 'nvcl-v2-borehole') {
-                    me.layerGroups[key].expanded = true;
-                    me.layerGroups[key].loaded = me.layerGroups[key];
-                    me.layerGroups[key][i].expanded = true;
-                  }
-                  me.uiLayerModelService.setUILayerModel(me.layerGroups[key][i].id, uiLayerModel);
-                }
+  /**
+   * Returns true if any layer in a layer group is visible in the sidebar
+   * "layerGroup" - an instance of this.layerGroups[key].value
+   */
+  public isLayerGroupVisible(layerGroupValue): boolean {
+      if (layerGroupValue.expanded && layerGroupValue.loaded) {
+          for (const layer of layerGroupValue.loaded) {
+              if (layer.hide === false) {
+                  return true;
               }
-            });
-        });
-        this.CsClipboardService.filterLayersBS.subscribe(
-          (bFilterLayers) => {
-            if (bFilterLayers) {
-              this.searchFilter();
-            } else {
-              this.clearSearch();
+          }
+      }
+      return false;
+  }
+
+  /**
+   * Clear the search result
+   */
+  public clearSearch() {
+    setTimeout(() => {
+      this.searchMode = false;
+      this.searchText = '';
+      this.search();
+    }, 0);
+  }
+
+  public ngOnInit() {
+      const nvclanid = UtilitiesService.getUrlParameterByName('nvclanid');
+      const state = UtilitiesService.getUrlParameterByName('state');
+      const me = this;
+      this.manageStateService.getUnCompressedString(state, function(result) {
+        const layerStateObj = JSON.parse(result);
+        if (!UtilitiesService.isEmpty(layerStateObj)) {
+          me.manageStateService.resumeMapState(layerStateObj.map);
+        }
+        me.layerHandlerService.getLayerRecord().subscribe(
+          response => {
+            me.layerGroups = response;
+            for (const key in me.layerGroups) {
+              for (let i = 0; i < me.layerGroups[key].length; i++) {
+                me.layerGroups[key][i].csLayers = [];
+                const uiLayerModel = new UILayerModel(me.layerGroups[key][i].id, me.renderStatusService.getStatusBSubject(me.layerGroups[key][i]));
+                // VT: permanent link
+                if (layerStateObj && layerStateObj[uiLayerModel.id]) {
+                  me.layerGroups[key].expanded = true;
+                  me.layerGroups[key].loaded = me.layerGroups[key];
+                  me.layerGroups[key][i].expanded = true;
+                  me.layerGroups[key][i].filterCollection.hiddenParams = layerStateObj[uiLayerModel.id].filterCollection.hiddenParams
+                  me.layerGroups[key][i].filterCollection.mandatoryFilters = layerStateObj[uiLayerModel.id].filterCollection.mandatoryFilters
+                }
+                // LJ: nvclAnalyticalJob link
+                if (nvclanid && uiLayerModel.id === 'nvcl-v2-borehole') {
+                  me.layerGroups[key].expanded = true;
+                  me.layerGroups[key].loaded = me.layerGroups[key];
+                  me.layerGroups[key][i].expanded = true;
+                }
+                me.uiLayerModelService.setUILayerModel(me.layerGroups[key][i].id, uiLayerModel);
+              }
             }
-        });
-    }
-
-    /**
-     * open the modal that display the status of the render
-     */
-    public openStatusReport(uiLayerModel: UILayerModel) {
-      this.bsModalRef = this.modalService.show(NgbdModalStatusReportComponent, {class: 'modal-lg'});
-      uiLayerModel.statusMap.getStatusBSubject().subscribe((value) => {
-        this.bsModalRef.content.resourceMap = value.resourceMap;
+          });
       });
-    }
+      this.CsClipboardService.filterLayersBS.subscribe(
+        (bFilterLayers) => {
+          if (bFilterLayers) {
+            this.searchFilter();
+          } else {
+            this.clearSearch();
+          }
+      });
+  }
 
-    /**
-     * remove the layer from the map
-     */
-    public removeLayer(layer: LayerModel) {
-      this.getUILayerModel(layer.id).opacity = 100;
-      this.csMapService.removeLayer(layer);
-    }
+  /**
+   * open the modal that display the status of the render
+   */
+  public openStatusReport(uiLayerModel: UILayerModel) {
+    this.bsModalRef = this.modalService.show(NgbdModalStatusReportComponent, {class: 'modal-lg'});
+    uiLayerModel.statusMap.getStatusBSubject().subscribe((value) => {
+      this.bsModalRef.content.resourceMap = value.resourceMap;
+    });
+  }
 
-    /**
-     * Layer opacity slider change event
-     */
-    public layerOpacityChange(event: MatSliderChange, layer: LayerModel) {
-      this.csMapService.setLayerOpacity(layer, (event.value / 100));
-    }
+  /**
+   * remove the layer from the map
+   */
+  public removeLayer(layer: LayerModel) {
+    this.getUILayerModel(layer.id).opacity = 100;
+    this.csMapService.removeLayer(layer);
+  }
 
-    /**
-     * Split buttons will only be displayed if the split map is shown and the layer has started (or completed) rendering
-     */
-    public getShowSplitMapButtons(layer: LayerModel): boolean {
-      return this.csMapService.getSplitMapShown() &&
-             (this.getUILayerModel(layer.id).statusMap.getRenderStarted() || this.getUILayerModel(layer.id).statusMap.getRenderComplete());
-    }
+  /**
+   * Layer opacity slider change event
+   */
+  public layerOpacityChange(event: MatSliderChange, layer: LayerModel) {
+    this.csMapService.setLayerOpacity(layer, (event.value / 100));
+  }
 
-    /**
-     * Set a layer's split direction so that it will appear in either the left, right or both (None) panes.
-     * 
-     * @param event the event trigger
-     * @param layer the layer to set split direction on
-     * @param direction the split direction for the layer to occupy
-     */
-    public setLayerSplitDirection(event: any, layer: LayerModel, direction: string) {
-      event.stopPropagation();
-      let splitDir: ImagerySplitDirection;
-      switch (direction) {
-        case "left":
-          splitDir = ImagerySplitDirection.LEFT;
+  /**
+   * Split buttons will only be displayed if the split map is shown and the layer has started (or completed) rendering
+   */
+  public getShowSplitMapButtons(layer: LayerModel): boolean {
+    return this.csMapService.getSplitMapShown() &&
+            (this.getUILayerModel(layer.id).statusMap.getRenderStarted() || this.getUILayerModel(layer.id).statusMap.getRenderComplete());
+  }
+
+  /**
+   * Set a layer's split direction so that it will appear in either the left, right or both (None) panes.
+   * 
+   * @param event the event trigger
+   * @param layer the layer to set split direction on
+   * @param direction the split direction for the layer to occupy
+   */
+  public setLayerSplitDirection(event: any, layer: LayerModel, direction: string) {
+    event.stopPropagation();
+    let splitDir: ImagerySplitDirection;
+    switch (direction) {
+      case "left":
+        splitDir = ImagerySplitDirection.LEFT;
+        break;
+      case "right":
+        splitDir = ImagerySplitDirection.RIGHT;
+        break;
+      case "none":
+      default:
+        splitDir = ImagerySplitDirection.NONE;
+        break;
+    }
+    layer.splitDirection = splitDir;
+    this.csMapService.setLayerSplitDirection(layer, splitDir);
+  }
+
+  public getLayerSplitDirection(layerId: string): string {
+    let splitDir = "none";
+    if (this.csMapService.getLayerModel(layerId) !== null) {
+      switch(this.csMapService.getLayerModel(layerId).splitDirection) {
+        case ImagerySplitDirection.LEFT:
+          splitDir = "left";
           break;
-        case "right":
-          splitDir = ImagerySplitDirection.RIGHT;
-          break;
-        case "none":
-        default:
-          splitDir = ImagerySplitDirection.NONE;
+        case ImagerySplitDirection.RIGHT:
+          splitDir = "right";
           break;
       }
-      layer.splitDirection = splitDir;
-      this.csMapService.setLayerSplitDirection(layer, splitDir);
     }
+    return splitDir;
+  }
 
-    public getLayerSplitDirection(layerId: string): string {
-      let splitDir = "none";
-      if (this.csMapService.getLayerModel(layerId) !== null) {
-        switch(this.csMapService.getLayerModel(layerId).splitDirection) {
-          case ImagerySplitDirection.LEFT:
-            splitDir = "left";
-            break;
-          case ImagerySplitDirection.RIGHT:
-            splitDir = "right";
-            break;
-        }
+  /**
+   * Only show the split map buttons if the layer has a WMS resource.
+   * 
+   * @param layer current LayerModel
+   */
+  public getApplicableSplitLayer(layer: LayerModel): boolean {
+    return this.layerHandlerService.contains(layer, ResourceType.WMS);
+  }
+
+  /**
+   * Returns true if any layer in a layer group is active 
+   * "layerGroup" - an instance of this.layerGroups[key].value
+   */
+  public isLayerGroupActive(layerGroupValue): boolean {
+    let activeLayers: string[] = Object.keys(this.csMapService.getLayerModelList());
+    for (const layer of layerGroupValue) {
+      if(activeLayers.indexOf(layer.id)>-1){
+        return true;
       }
-      return splitDir;
     }
-
-    /**
-     * Only show the split map buttons if the layer has a WMS resource.
-     * 
-     * @param layer current LayerModel
-     */
-    public getApplicableSplitLayer(layer: LayerModel): boolean {
-      return this.layerHandlerService.contains(layer, ResourceType.WMS);
-    }
-
-    /**
-     * Returns true if any layer in a layer group is active 
-     * "layerGroup" - an instance of this.layerGroups[key].value
-     */
-    public isLayerGroupActive(layerGroupValue): boolean {
-      let activeLayers: string[] = Object.keys(this.csMapService.getLayerModelList());
-      for (const layer of layerGroupValue) {
-        if(activeLayers.indexOf(layer.id)>-1){
-          return true;
-        }
-      }
-     return false;
+   return false;
   }
 
   public getUILayerModel(layerId: string): UILayerModel {
     return this.uiLayerModelService.getUILayerModel(layerId);
+  }
+
+  /**
+   * Turn off Filter Layers (Polygon Filter)
+   */
+  public removeFilterLayers() {
+    this.CsClipboardService.toggleFilterLayers(false);
   }
 
 }

--- a/project/src/app/menupanel/menupanel.scss
+++ b/project/src/app/menupanel/menupanel.scss
@@ -322,3 +322,16 @@ input + div.input-group-append  > button {
 .help-block {
     color: $auscope-grey;
 }
+
+/* All Layers -> Filtered Layers box */
+.filtered-layers {
+    display: flex;
+    color: $auscope-grey;
+    align-items: baseline;
+    text-align: center;
+    font-size: small;
+    border: solid 1px $auscope-grey;
+    border-radius: 5px;
+    padding: 5px 5px 0 0;
+    margin: 5px 8px 5px 0;
+}

--- a/project/src/app/modalwindow/querier/querier.modal.component.ts
+++ b/project/src/app/modalwindow/querier/querier.modal.component.ts
@@ -115,6 +115,7 @@ export class QuerierModalComponent {
     if (polygon !== null) {
       this.CsClipboardService.addPolygon(polygon);
       this.CsClipboardService.toggleClipboard(true);
+      this.appRef.tick();
     }
   }
   public onDataChange(): void {

--- a/project/src/app/modalwindow/querier/querier.modal.component.ts
+++ b/project/src/app/modalwindow/querier/querier.modal.component.ts
@@ -1,4 +1,3 @@
-
 import {UtilitiesService} from '@auscope/portal-core-ui';
 import {Component} from '@angular/core';
 import {environment} from '../../../environments/environment';

--- a/project/src/environments/config.ts
+++ b/project/src/environments/config.ts
@@ -145,7 +145,6 @@ export const config = {
   ],
   clipboard: {
     'supportedLayersRegKeyword': '(ProvinceFullExtent)',
-    'supportedLayersRegName': '(Geological Provinces)',
     'mineraltenement': {
       'srsName': 'EPSG:4326',
       'nameKeyword': 'name',

--- a/project/src/environments/ref.ts
+++ b/project/src/environments/ref.ts
@@ -2,14 +2,14 @@
 // I.E. when a layer has an additional analytic or advanced filter component it is linked to the layer here.
 
 
-import {CapdfAdvanceFilterComponent} from '../app/menupanel/common/filterpanel/advance/capdf/capdf.advancefilter.component';
-import {CapdfAnalyticComponent} from '../app/modalwindow/layeranalytic/capdf/capdf.analytic.component';
-import {NVCLBoreholeAnalyticComponent} from '../app/modalwindow/layeranalytic/nvcl/nvcl.boreholeanalytic.component';
+import { CapdfAdvanceFilterComponent } from '../app/menupanel/common/filterpanel/advance/capdf/capdf.advancefilter.component';
+import { CapdfAnalyticComponent } from '../app/modalwindow/layeranalytic/capdf/capdf.analytic.component';
+import { NVCLBoreholeAnalyticComponent } from '../app/modalwindow/layeranalytic/nvcl/nvcl.boreholeanalytic.component';
 import { RemanentAnomaliesComponent } from '../app/modalwindow/querier/customanalytic/RemanentAnomalies/remanentanomalies.component';
-import {NVCLDatasetListComponent} from '../app/modalwindow/querier/customanalytic/nvcl/nvcl.datasetlist.component';
-import {TIMAComponent} from '../app/modalwindow/querier/customanalytic/tima/tima.component';
-import {IrisQuerierHandler} from '../app/cesium-map/custom-querier-handler/iris-querier-handler.service';
-import {MSCLComponent} from '../app/modalwindow/querier/customanalytic/mscl/mscl.component';
+import { NVCLDatasetListComponent } from '../app/modalwindow/querier/customanalytic/nvcl/nvcl.datasetlist.component';
+import { TIMAComponent } from '../app/modalwindow/querier/customanalytic/tima/tima.component';
+import { IrisQuerierHandler } from '../app/cesium-map/custom-querier-handler/iris-querier-handler.service';
+import { MSCLComponent } from '../app/modalwindow/querier/customanalytic/mscl/mscl.component';
 
 export const ref = {
   analytic: {
@@ -26,8 +26,5 @@ export const ref = {
   },
   advanceFilter: {
     'capdf-hydrogeochem': CapdfAdvanceFilterComponent
-  },
-  customQuerierHandler: {
-    'seismology-in-schools-site': IrisQuerierHandler,
   }
 };


### PR DESCRIPTION
Added a message to layer panel saying polygon filter layers have been toggled and a button to clear toggle.
Get name of polygon to display in clipboard from polygon object. 
Filter layers are now determined by the presence of a BBOX filter instead of a config setting.
Enable/disable polygon filter buttons depending on state.
Fixed bug where clearing an applied polygon then re-adding layer would still filter to polygon.
All searches now check if polygon layers have been filtered and will only show those layers if they have.
All searches now expand layer groups that contain results to display layers.