### PR TITLE
AUS-3793 Unsupported Type Click Error

### DIFF
--- a/src/app/cesium-map/csmap.component.ts
+++ b/src/app/cesium-map/csmap.component.ts
@@ -354,9 +354,19 @@ export class CsMapComponent implements AfterViewInit {
     for (const maplayer of mapClickInfo.clickedLayerList) {
       for (const i of maplayer.clickCSWRecordsIndex ) {
         const cswRecord = maplayer.cswRecords[i];
-        const onlineResource = cswRecord.onlineResources[0];
-        if (onlineResource) {
 
+        // Bail if no OnlineResources
+        if (!cswRecord.onlineResources || cswRecord.onlineResources.length === 0) {
+          return;
+        }
+
+        // Get the WMS OnlineResource, if that fails use the first in the list
+        let onlineResource = cswRecord.onlineResources.find(or => or.type === ResourceType.WMS);
+        if (!onlineResource && cswRecord.onlineResources[0]) {
+          onlineResource = cswRecord.onlineResources[0];
+        }
+
+        if (onlineResource) {
           // Display CSW record info
           if (config.cswrenderer.includes(maplayer.id)) {
             me.displayModal(mapClickInfo.clickCoord);

--- a/src/app/cesium-map/csmap.component.ts
+++ b/src/app/cesium-map/csmap.component.ts
@@ -357,7 +357,7 @@ export class CsMapComponent implements AfterViewInit {
 
         // Bail if no OnlineResources
         if (!cswRecord.onlineResources || cswRecord.onlineResources.length === 0) {
-          return;
+          continue;
         }
 
         // Get the WMS OnlineResource, if that fails use the first in the list


### PR DESCRIPTION
Fixed error where layers with OnlineResources of type "Unsupported" were showing server errors in the feature dialog when clicked due to the click handler taking the first OnlineResource rather than specifically asking for the WMS one.