### PR TITLE
AUS-3871 Filter/Layer panel UI tweaks

### DIFF
--- a/src/app/menupanel/common/filterpanel/advance/grace/grace-advanced-filter.component.scss
+++ b/src/app/menupanel/common/filterpanel/advance/grace/grace-advanced-filter.component.scss
@@ -1,10 +1,11 @@
 :host {
     .grace-advancedfilter {
-        margin-left: 33px;
-        margin-right: 33px;
+        margin-left: 1.3em;
+        margin-right: 1.3em;
     }
 
     .style-form {
+        width: 100%;
         padding: 8px;
         border: 1px solid cadetblue;
         margin-bottom: 10px;

--- a/src/app/menupanel/common/filterpanel/filterpanel.component.html
+++ b/src/app/menupanel/common/filterpanel/filterpanel.component.html
@@ -39,13 +39,13 @@
 	<fieldset *ngIf="layerFilterCollection && layerFilterCollection['optionalFilters']" class="show-fieldset-borders">
 		<legend><h5>Optional Filters</h5></legend>
 		<div class="form-group form-group-sm">
-			<label style="display:flex;" *ngIf="optionalFilters.length > 0" title="Remove filter"> Select Filter:<i style="margin-left:auto;" class="hasEvent red" (click)="refreshFilter()">Clear All</i></label>
+			<label style="display:flex;font-size:0.9rem;" *ngIf="optionalFilters.length > 0" title="Remove filter"> Select Filter:<i style="margin-left:auto;font-size:0.9rem;" class="hasEvent red" (click)="refreshFilter()">Clear All</i></label>
 			<select class="form-control form-control-sm" [ngModel]="selectedFilter" (ngModelChange)="addFilter($event)">
 				<option [ngValue]="filt" *ngFor="let filt of layerFilterCollection['optionalFilters']">{{filt.label}}</option>
 			</select>
 		</div>
-		<hr class="nav-divider">
-		<div *ngFor="let optionalFilter of optionalFilters">
+		<hr *ngIf="optionalFilters.length > 0" class="nav-divider filter-divider">
+		<div *ngFor="let optionalFilter of optionalFilters; let i = index;">
 			<div *ngIf="optionalFilter.type=='OPTIONAL.TEXT'">
 				<div class="form-group  form-group-sm">
 					<label>{{optionalFilter.label}}:</label>
@@ -105,10 +105,10 @@
 			</div>
 
 			<div  class="d-none d-md-block" *ngIf="optionalFilter.type=='OPTIONAL.POLYGONBBOX'">
-				<div class="form-group  form-group-sm">
+				<div class="form-group form-group-sm">
 					<div class="checkbox" >
-							<input class="form-control-sm" id="{{ 'filter-OPTIONAL.POLYGONBBOX-0-' + layer.id }}" type="checkbox" [(ngModel)]="bApplyClipboardBBox"/>
-							<label for="{{ 'filter-OPTIONAL.POLYGONBBOX-0-' + layer.id }}">Apply clipboard BBox</label>
+						<input class="form-control-sm" id="{{ 'filter-OPTIONAL.POLYGONBBOX-0-' + layer.id }}" type="checkbox" [(ngModel)]="bApplyClipboardBBox"/>
+						<label for="{{ 'filter-OPTIONAL.POLYGONBBOX-0-' + layer.id }}">Apply clipboard BBox</label>
 					</div>
 				</div>
 			</div>
@@ -118,6 +118,7 @@
 					<p>This filter is not supported on a small screen and would not return any results.</p>
 				</div>
 			</div>
+			<hr *ngIf="i < optionalFilters.length - 1" class="nav-divider filter-divider">
 		</div>
 	</fieldset>
 
@@ -138,8 +139,8 @@
 
 	<p *ngIf='layerStatus.isLayerDown(layer.id)' class='small text-danger'><i class="fa fa-warning text-warning"></i> One or more of the services used by this layer are reported to be experiencing issues at the moment. Click on the info panel for more information.</p>
 	<div>
-		<button *ngIf="analyticMap[layer.id]" type="button" class="btn btn-warning btn-sm" title="Display analytics" (click)="processLayerAnalytic(layer)"><i class="fa fa-bar-chart" aria-hidden="true"></i>&nbsp;Analytic</button>
-		<button type="button" *ngIf="isMapSupportedLayer(layer)" class="btn btn-info btn-sm float-right" (click)="addLayer(layer)"><i class="fa fa-plus-circle" aria-hidden="true"></i>&nbsp;Add Layer</button>
+		<button *ngIf="analyticMap[layer.id]" type="button" class="btn btn-warning btn-sm analytic-btn" title="Display analytics" (click)="processLayerAnalytic(layer)"><i class="fa fa-bar-chart" aria-hidden="true"></i>&nbsp;Analytic</button>
+		<button type="button" *ngIf="isMapSupportedLayer(layer)" class="btn btn-info btn-sm add-layer-btn float-right" (click)="addLayer(layer)"><i class="fa fa-plus-circle" aria-hidden="true"></i>&nbsp;Add Layer</button>
 		<div class="unsupported-layer-message" *ngIf="!isMapSupportedLayer(layer)">
 			<em class="fa fa-exclamation-triangle warning-icon"></em>
 			{{ getUnsupportedLayerMessage() }}

--- a/src/app/menupanel/common/filterpanel/filterpanel.component.scss
+++ b/src/app/menupanel/common/filterpanel/filterpanel.component.scss
@@ -30,8 +30,26 @@ div.red {
     .mat-radio-outer-circle {
         border-color: white;
     }
+
+    .alert.alert-warning.fade.show {
+        margin-left: 0;
+        margin-right: 0;
+    }
+}
+
+.filter-divider {
+    border-color: lightgray;
 }
 
 .date-btn {
-    position: absolute;
+    position: fixed;
+    left: 0;
+}
+
+.add-layer-btn {
+    margin: 0 0em 0.5em 0;
+}
+
+.analytic-btn {
+    margin-left: 0;
 }

--- a/src/app/menupanel/layerpanel/layerpanel.component.html
+++ b/src/app/menupanel/layerpanel/layerpanel.component.html
@@ -53,7 +53,7 @@
 					</div>
 				</a>
 				<div [hidden]="!layer.expanded || layer.hide" class="sidebar-card-menu-show">
-					<div class="card card-info card-with-tabs layer-card animated  slideInRight">						
+					<div class="card card-info card-with-tabs layer-card animated slideInRight">						
 						<div class = "rh_info_wrap">	
 							<div class="card-header">
 								<ul id="card-tab" class="nav nav-tabs">
@@ -62,7 +62,7 @@
 								</ul>
 							</div>
 							<div class="rh_info">																	
-								<button (click)="displayRecordInformation(layer)" class="btn-info" title="Information" [ngClass]="{'active': getUILayerModel(layer.id) && getUILayerModel(layer.id).tabpanel.infopanel.expanded}">info</button>
+								<button (click)="displayRecordInformation(layer)" class="btn btn-sm btn-info layer-info-btn" title="Information" [ngClass]="{'active': getUILayerModel(layer.id) && getUILayerModel(layer.id).tabpanel.infopanel.expanded}">info</button>
 							</div>
 						</div>
 

--- a/src/app/menupanel/layerpanel/layerpanel.component.scss
+++ b/src/app/menupanel/layerpanel/layerpanel.component.scss
@@ -15,10 +15,6 @@
         }
     }
 
-    .layer-card {
-        margin-left: 5px;
-    }
-
     .layer-info-btn {
         position: absolute;
         top: 1.4em;

--- a/src/app/menupanel/layerpanel/layerpanel.component.scss
+++ b/src/app/menupanel/layerpanel/layerpanel.component.scss
@@ -1,0 +1,28 @@
+:host {
+
+    ::ng-deep {
+        fieldset.show-fieldset-borders {
+            margin: 0 0 1em 0;
+            padding: 0 1.4em 0.5em 1.4em;
+        }
+
+        fieldset legend {
+            width: 50%;
+        }
+
+        .tab-content {
+            padding: 15px 15px 6px 15px;
+        }
+    }
+
+    .layer-card {
+        margin-left: 5px;
+    }
+
+    .layer-info-btn {
+        position: absolute;
+        top: 1.4em;
+        right: 1.3em;
+    }
+
+}

--- a/src/app/menupanel/layerpanel/layerpanel.component.ts
+++ b/src/app/menupanel/layerpanel/layerpanel.component.ts
@@ -26,7 +26,7 @@ enum FilterMode {
 @Component({
     selector: '[appLayerPanel]',
     templateUrl: './layerpanel.component.html',
-    styleUrls: ['../menupanel.scss']
+    styleUrls: ['../menupanel.scss', './layerpanel.component.scss']
 })
 export class LayerPanelComponent implements OnInit {
 


### PR DESCRIPTION
Small UI fixes:
* Filter panel shifted right a tiny amount so it’s not on the edge of the screen.
* A little less padding at bottom of filter panel.
* Filter panel title width reduced so top panel border line comes closer to title.
* Filter panel left/right margins reduced so it aligns with the tab panel.
* Info button using Bootstrap L&F.
* Add layer button shifted slightly to align with (new) filter panel right edge.
* Added filter divider made light grey so it’s visible and hidden if no filters have been added.
* A tad less room under Add Layer button.
* Adjusted filter notification so it aligns with slightly wider filter panel.
* GRACE panel adjustments to match above.