### PR TITLE
AUS-3875 Remove default data search

### DIFF
--- a/src/app/menupanel/data-explorer/data-explorer.component.html
+++ b/src/app/menupanel/data-explorer/data-explorer.component.html
@@ -187,8 +187,13 @@
                         <i *ngIf="!searchResultsIsCollapsed" style="line-height:inherit;" class="fa fa-arrow-circle-up pull-right"></i>
                     </span>
                 </div>
-                <div [ngbCollapse]="searchResultsIsCollapsed" id="searchResults" >
-                    <fieldset >
+                <div [ngbCollapse]="searchResultsIsCollapsed" id="searchResults">
+                    <!-- Searches aren't run automatically any more, hide results until a search has been done -->
+                    <div *ngIf="!searchConducted" class="no-search-notification">
+                        To search CSW services enter a search term, add any desired filters and press the search button above.
+                    </div>
+                    <!-- Search results -->
+                    <fieldset *ngIf="searchConducted">
                         <legend class="control-label small" >Results ({{ getTotalSearchResultCount() }} Total)</legend>
                         <div class="container-fluid" style="margin: 0px; padding: 0px;">
                             <ul ngbNav #nav="ngbNav" class="nav-pills" >
@@ -205,7 +210,7 @@
                                             </div>
                                         </div>
                                         <!-- Server error -->
-                                        <div *ngIf="!registry.value.searching && registry.value.searchError!==null">
+                                        <div *ngIf="!registry.value.searching && registry.value.searchError && registry.value.searchError!==''">
                                             <div class="row" style="padding:10px;">
                                                 <div class="col" style="padding:10px;border:solid 1px black;border-radius:8px;word-break:break-all;background:#EBF5FB;color: black;">
                                                     <label>This registry reported a problem:<br><br>{{ registry.value.searchError }}</label>

--- a/src/app/menupanel/data-explorer/data-explorer.component.html
+++ b/src/app/menupanel/data-explorer/data-explorer.component.html
@@ -2,6 +2,15 @@
     <div class="card">
         <div class="card-body" style="padding-left: 0px;padding-right: 0px;">
 
+            <!-- Searches aren't run automatically any more, hide results and display message until a search has been done -->
+            <div class="row" *ngIf="!searchConducted">
+                <div class="col">
+                    <div class="no-search-notification">
+                        To search CSW services enter a search term, add any desired filters and press the search button below.
+                    </div>
+                </div>
+            </div>
+
             <!-- Any text search -->
             <div class="row">
                 <div class="col">
@@ -175,9 +184,8 @@
             </div>
 
             <!-- Search results -->
-            <div class="row" #searchResults>
+            <div class="row" #searchResults *ngIf="searchConducted">
                 <div class="col">
-
                 <div class="submenu-header" (click)="searchResultsIsCollapsed = !searchResultsIsCollapsed">
                     Search Results
                     <span>
@@ -188,12 +196,8 @@
                     </span>
                 </div>
                 <div [ngbCollapse]="searchResultsIsCollapsed" id="searchResults">
-                    <!-- Searches aren't run automatically any more, hide results until a search has been done -->
-                    <div *ngIf="!searchConducted" class="no-search-notification">
-                        To search CSW services enter a search term, add any desired filters and press the search button above.
-                    </div>
                     <!-- Search results -->
-                    <fieldset *ngIf="searchConducted">
+                    <fieldset>
                         <legend class="control-label small" >Results ({{ getTotalSearchResultCount() }} Total)</legend>
                         <div class="container-fluid" style="margin: 0px; padding: 0px;">
                             <ul ngbNav #nav="ngbNav" class="nav-pills" >

--- a/src/app/menupanel/data-explorer/data-explorer.component.scss
+++ b/src/app/menupanel/data-explorer/data-explorer.component.scss
@@ -74,7 +74,6 @@
                 border: solid 1px white;
                 border-radius: 6px;
                 padding: 10px;
-                margin-top: 10px;
             }
 
             #no-result-container{

--- a/src/app/menupanel/data-explorer/data-explorer.component.scss
+++ b/src/app/menupanel/data-explorer/data-explorer.component.scss
@@ -56,6 +56,7 @@
                     width:auto;
                     margin-left:4px;
                 }
+
                 .input-group{
                     margin-left:4px;
                     margin-right:4px;
@@ -68,6 +69,14 @@
                     padding: 0px;
                 }
             }
+
+            .no-search-notification {
+                border: solid 1px white;
+                border-radius: 6px;
+                padding: 10px;
+                margin-top: 10px;
+            }
+
             #no-result-container{
                 padding:2px;
                 border:solid 1px $auscope-grey;

--- a/src/app/menupanel/data-explorer/data-explorer.component.ts
+++ b/src/app/menupanel/data-explorer/data-explorer.component.ts
@@ -100,7 +100,6 @@ export class DataExplorerComponent implements OnInit{
         // facetedSearch to ensure at least 1 filter has been used or de-
         // selecting a registry will populate results)
         this.getFacetedKeywords();
-        //this.facetedSearchAllRegistries();
       },
       (error) => {
         // TODO: Proper error reporting

--- a/src/app/menupanel/data-explorer/data-explorer.component.ts
+++ b/src/app/menupanel/data-explorer/data-explorer.component.ts
@@ -27,6 +27,7 @@ export class DataExplorerComponent implements OnInit{
 
   // Search results
   cswSearchResults: Map<String, LayerModel[]> = new Map<String, LayerModel[]>();
+  searchConducted = false;  // Has a search has been conducted?
   layerOpacities: Map<String, number> = new Map<String, number>();
 
   // Collapsable menus
@@ -37,8 +38,6 @@ export class DataExplorerComponent implements OnInit{
   pubDateIsCollapsed: boolean = true;
   registriesIsCollapsed: boolean = true;
   searchResultsIsCollapsed: boolean = true;
-
-
 
   // Faceted search parameters
   anyTextValue: string = "";
@@ -87,7 +86,7 @@ export class DataExplorerComponent implements OnInit{
     this.dataExplorerService.updateRegistries().subscribe(
       (data: Registry[]) => {
         // Update registries
-        for (let registry of data) {
+        for (const registry of data) {
           registry.checked = true;
           registry.startIndex = 1;
           registry.prevIndices = [];
@@ -101,7 +100,7 @@ export class DataExplorerComponent implements OnInit{
         // facetedSearch to ensure at least 1 filter has been used or de-
         // selecting a registry will populate results)
         this.getFacetedKeywords();
-        this.facetedSearchAllRegistries();
+        //this.facetedSearchAllRegistries();
       },
       (error) => {
         // TODO: Proper error reporting
@@ -153,6 +152,8 @@ export class DataExplorerComponent implements OnInit{
    * Search all registries using current facets.
    */
   public facetedSearchAllRegistries(): void {
+
+    this.searchConducted = true;
 
     // Available registries and start
     let serviceIds: string[] = [];
@@ -270,7 +271,6 @@ export class DataExplorerComponent implements OnInit{
                   registry.searchError =
                     response["data"].searchErrors[registry.id];
                 }
-                
 
                   for (let i = 0; i < response["itemLayers"].length; i++) {
                     const uiLayerModel = new UILayerModel(
@@ -284,7 +284,7 @@ export class DataExplorerComponent implements OnInit{
                       uiLayerModel
                     );
                   }
-                        
+
                 this.cswSearchResults.set(registry.id, response["itemLayers"]);
                 registry.searching = false;
 
@@ -306,6 +306,8 @@ export class DataExplorerComponent implements OnInit{
    * @param registry the single registry to search
    */
   public facetedSearchSingleRegistry(registry: Registry): void {
+
+    this.searchConducted = true;
 
     let fields: string[] = [];
     let values: string[] = [];

--- a/src/app/menupanel/data-explorer/data-explorer.service.ts
+++ b/src/app/menupanel/data-explorer/data-explorer.service.ts
@@ -14,11 +14,11 @@ export class DataExplorerService {
 
   static RESULTS_PER_PAGE: number = 35;
 
-  constructor(private http: HttpClient) { }
-
   private _registries: BehaviorSubject<Registry[]> = new BehaviorSubject([]);
   public readonly registries: Observable<Registry[]> = this._registries.asObservable();
-  
+
+  constructor(private http: HttpClient) { }
+
   public getFilteredCSWKeywords(cswServiceId: string): Observable<any> {
     let httpParams = new HttpParams();
     httpParams = httpParams.append('cswServiceIds', cswServiceId);
@@ -153,11 +153,11 @@ export class DataExplorerService {
      * executes getFacetedCSWServices.do in vgl service
      */
     public updateRegistries(): Observable<Registry[]> {
-      let obs = this.getCSWServices();
+      const obs = this.getCSWServices();
       obs.subscribe(registryList => this._registries.next(registryList));
       return obs;
-  } 
-  
+  }
+
  /**
      * @param serviceId
      * @param start
@@ -225,10 +225,10 @@ export class DataExplorerService {
           // return response['data'];
           return {
             itemLayers: itemLayers,
-            data:response['data']
+            data: response['data']
           }
       }));
-  }  
+  }
 
     /**
      * Returns an array of keywords for specified service IDs

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,7 +134,7 @@
     "ora" "5.4.1"
     "rxjs" "6.6.7"
 
-"@angular/animations@^13.0.0", "@angular/animations@^13.0.0 || ^14.0.0-0", "@angular/animations@^13.3.11", "@angular/animations@>=10.0.4", "@angular/animations@>=12.0.0", "@angular/animations@~13.3.11", "@angular/animations@13.3.12":
+"@angular/animations@^13.0.0", "@angular/animations@^13.0.0 || ^14.0.0-0", "@angular/animations@^13.3.11", "@angular/animations@>=10.0.4", "@angular/animations@>=12.0.0", "@angular/animations@13.3.12":
   "integrity" "sha512-dc2JDokKJuuNxzzZa9FvuQU71kYC/e0xCLjGxEgX48sGKwajHRGBuzYFb8EmvLeA24SshYGmrxN0vGG9GhLK6g=="
   "resolved" "https://registry.npmjs.org/@angular/animations/-/animations-13.3.12.tgz"
   "version" "13.3.12"
@@ -198,7 +198,7 @@
     "tslib" "^2.3.0"
     "yargs" "^17.2.1"
 
-"@angular/compiler@^13.3.11", "@angular/compiler@~13.3.11", "@angular/compiler@13.3.12":
+"@angular/compiler@^13.3.11", "@angular/compiler@13.3.12":
   "integrity" "sha512-F5vJYrjbNvEWoVz9J/CqiT3Iod6g9bV0dGI5EeURcW4yHXHZ12ioQpfU3+bE7qXcTlnofbdDhK8cGxGx01SzBA=="
   "resolved" "https://registry.npmjs.org/@angular/compiler/-/compiler-13.3.12.tgz"
   "version" "13.3.12"
@@ -222,7 +222,7 @@
   "resolved" "https://registry.npmjs.org/@angular/core/-/core-9.0.0.tgz"
   "version" "9.0.0"
 
-"@angular/forms@^13.0.0", "@angular/forms@^13.0.0 || ^14.0.0-0", "@angular/forms@^13.3.11", "@angular/forms@>=10.0.4", "@angular/forms@>=12.0.0", "@angular/forms@>=13.0.0 <14.0.0", "@angular/forms@~13.3.11":
+"@angular/forms@^13.0.0", "@angular/forms@^13.0.0 || ^14.0.0-0", "@angular/forms@^13.3.11", "@angular/forms@>=10.0.4", "@angular/forms@>=12.0.0", "@angular/forms@>=13.0.0 <14.0.0":
   "integrity" "sha512-auow1TKZx44ha1ia8Jwg2xp2Q7BbpShG5Ft8tewL3T44aTmJY7svWOE/m+DkZ/SXHmTFnbZFobGU5aEfe0+pNw=="
   "resolved" "https://registry.npmjs.org/@angular/forms/-/forms-13.3.12.tgz"
   "version" "13.3.12"
@@ -250,14 +250,14 @@
   dependencies:
     "tslib" "^2.3.0"
 
-"@angular/platform-browser-dynamic@^13.3.11", "@angular/platform-browser-dynamic@>=12.0.0", "@angular/platform-browser-dynamic@~13.3.11", "@angular/platform-browser-dynamic@13.3.12":
+"@angular/platform-browser-dynamic@^13.3.11", "@angular/platform-browser-dynamic@>=12.0.0", "@angular/platform-browser-dynamic@13.3.12":
   "integrity" "sha512-/hBggov0PxK/KNJqIu3MVc5k8f0iDbygDP8Z1k/J0FcllOSRdO4LsQd1fsCfGfwIUf0YWGyD7KraSGpBBiWlFg=="
   "resolved" "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-13.3.12.tgz"
   "version" "13.3.12"
   dependencies:
     "tslib" "^2.3.0"
 
-"@angular/platform-browser@^13.0.0 || ^14.0.0-0", "@angular/platform-browser@^13.3.11", "@angular/platform-browser@>=12.0.0", "@angular/platform-browser@~13.3.11", "@angular/platform-browser@13.3.12":
+"@angular/platform-browser@^13.0.0 || ^14.0.0-0", "@angular/platform-browser@^13.3.11", "@angular/platform-browser@>=12.0.0", "@angular/platform-browser@13.3.12":
   "integrity" "sha512-sfhQqU4xjTJCjkH62TQeH5/gkay/KzvNDF95J6NHi/Q6p2dbtzZdXuLJKR/sHxtF2kc505z5v9RNm6XMSXM1KA=="
   "resolved" "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-13.3.12.tgz"
   "version" "13.3.12"
@@ -273,7 +273,7 @@
     "tslib" "^2.3.0"
     "xhr2" "^0.2.0"
 
-"@angular/router@^13.3.11", "@angular/router@~13.3.11":
+"@angular/router@^13.3.11":
   "integrity" "sha512-X+TAxTAlqUd2gPm6drFBGVzQsbQWM5wmZ8S5D5i+86x7Ku0v2CUFICT6AUPSl9+FTPiexlL4FdmvQV2CnGTSUw=="
   "resolved" "https://registry.npmjs.org/@angular/router/-/router-13.3.12.tgz"
   "version" "13.3.12"
@@ -306,10 +306,9 @@
   dependencies:
     "tslib" "^2.3.0"
 
-"@auscope/portal-core-ui@^1.0.61":
-  "integrity" "sha512-YuIOC4DZ8H8q60rri1R/Xfi1d3JunhxHE3hgcdvVGrLDC2Qbcf3rhIYl90YrSWdh5KicctdCCWZwsjd+2z7w1Q=="
-  "resolved" "https://registry.npmjs.org/@auscope/portal-core-ui/-/portal-core-ui-1.0.61.tgz"
-  "version" "1.0.61"
+"@auscope/portal-core-ui@file:../portal-core-ui-app/dist/portal-core-ui":
+  "resolved" "file:../portal-core-ui-app/dist/portal-core-ui"
+  "version" "0.0.0-watch+1670989006246"
   dependencies:
     "tslib" "^2.4.1"
 
@@ -2862,7 +2861,7 @@
   "resolved" "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
   "version" "0.12.0"
 
-"cesium@>= 1.93.0", "cesium@1.93", "cesium@1.93.0":
+"cesium@>= 1.93.0", "cesium@1.93":
   "integrity" "sha512-y5+KkISn3+0MZxGj96mNaZc5LAfpiOs1fmZCInH2xHwYw43FaaRbvdSHXZs8OwJ5dZIlo/m1biMyOKr354L+UA=="
   "resolved" "https://registry.npmjs.org/cesium/-/cesium-1.93.0.tgz"
   "version" "1.93.0"
@@ -8407,7 +8406,7 @@
   "resolved" "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz"
   "version" "0.1.4"
 
-"when@^3.7.8", "when@~3.7.8":
+"when@^3.7.8":
   "integrity" "sha512-5cZ7mecD3eYcMiCH4wtRPA5iFJZ50BJYDfckI5RRpQiktMiYTcn0ccLTZOvcbBume+1304fQztxeNzNS9Gvrnw=="
   "resolved" "https://registry.npmjs.org/when/-/when-3.7.8.tgz"
   "version" "3.7.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -134,7 +134,7 @@
     "ora" "5.4.1"
     "rxjs" "6.6.7"
 
-"@angular/animations@^13.0.0", "@angular/animations@^13.0.0 || ^14.0.0-0", "@angular/animations@^13.3.11", "@angular/animations@>=10.0.4", "@angular/animations@>=12.0.0", "@angular/animations@13.3.12":
+"@angular/animations@^13.0.0", "@angular/animations@^13.0.0 || ^14.0.0-0", "@angular/animations@^13.3.11", "@angular/animations@>=10.0.4", "@angular/animations@>=12.0.0", "@angular/animations@~13.3.11", "@angular/animations@13.3.12":
   "integrity" "sha512-dc2JDokKJuuNxzzZa9FvuQU71kYC/e0xCLjGxEgX48sGKwajHRGBuzYFb8EmvLeA24SshYGmrxN0vGG9GhLK6g=="
   "resolved" "https://registry.npmjs.org/@angular/animations/-/animations-13.3.12.tgz"
   "version" "13.3.12"
@@ -198,7 +198,7 @@
     "tslib" "^2.3.0"
     "yargs" "^17.2.1"
 
-"@angular/compiler@^13.3.11", "@angular/compiler@13.3.12":
+"@angular/compiler@^13.3.11", "@angular/compiler@~13.3.11", "@angular/compiler@13.3.12":
   "integrity" "sha512-F5vJYrjbNvEWoVz9J/CqiT3Iod6g9bV0dGI5EeURcW4yHXHZ12ioQpfU3+bE7qXcTlnofbdDhK8cGxGx01SzBA=="
   "resolved" "https://registry.npmjs.org/@angular/compiler/-/compiler-13.3.12.tgz"
   "version" "13.3.12"
@@ -222,7 +222,7 @@
   "resolved" "https://registry.npmjs.org/@angular/core/-/core-9.0.0.tgz"
   "version" "9.0.0"
 
-"@angular/forms@^13.0.0", "@angular/forms@^13.0.0 || ^14.0.0-0", "@angular/forms@^13.3.11", "@angular/forms@>=10.0.4", "@angular/forms@>=12.0.0", "@angular/forms@>=13.0.0 <14.0.0":
+"@angular/forms@^13.0.0", "@angular/forms@^13.0.0 || ^14.0.0-0", "@angular/forms@^13.3.11", "@angular/forms@>=10.0.4", "@angular/forms@>=12.0.0", "@angular/forms@>=13.0.0 <14.0.0", "@angular/forms@~13.3.11":
   "integrity" "sha512-auow1TKZx44ha1ia8Jwg2xp2Q7BbpShG5Ft8tewL3T44aTmJY7svWOE/m+DkZ/SXHmTFnbZFobGU5aEfe0+pNw=="
   "resolved" "https://registry.npmjs.org/@angular/forms/-/forms-13.3.12.tgz"
   "version" "13.3.12"
@@ -250,14 +250,14 @@
   dependencies:
     "tslib" "^2.3.0"
 
-"@angular/platform-browser-dynamic@^13.3.11", "@angular/platform-browser-dynamic@>=12.0.0", "@angular/platform-browser-dynamic@13.3.12":
+"@angular/platform-browser-dynamic@^13.3.11", "@angular/platform-browser-dynamic@>=12.0.0", "@angular/platform-browser-dynamic@~13.3.11", "@angular/platform-browser-dynamic@13.3.12":
   "integrity" "sha512-/hBggov0PxK/KNJqIu3MVc5k8f0iDbygDP8Z1k/J0FcllOSRdO4LsQd1fsCfGfwIUf0YWGyD7KraSGpBBiWlFg=="
   "resolved" "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-13.3.12.tgz"
   "version" "13.3.12"
   dependencies:
     "tslib" "^2.3.0"
 
-"@angular/platform-browser@^13.0.0 || ^14.0.0-0", "@angular/platform-browser@^13.3.11", "@angular/platform-browser@>=12.0.0", "@angular/platform-browser@13.3.12":
+"@angular/platform-browser@^13.0.0 || ^14.0.0-0", "@angular/platform-browser@^13.3.11", "@angular/platform-browser@>=12.0.0", "@angular/platform-browser@~13.3.11", "@angular/platform-browser@13.3.12":
   "integrity" "sha512-sfhQqU4xjTJCjkH62TQeH5/gkay/KzvNDF95J6NHi/Q6p2dbtzZdXuLJKR/sHxtF2kc505z5v9RNm6XMSXM1KA=="
   "resolved" "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-13.3.12.tgz"
   "version" "13.3.12"
@@ -273,7 +273,7 @@
     "tslib" "^2.3.0"
     "xhr2" "^0.2.0"
 
-"@angular/router@^13.3.11":
+"@angular/router@^13.3.11", "@angular/router@~13.3.11":
   "integrity" "sha512-X+TAxTAlqUd2gPm6drFBGVzQsbQWM5wmZ8S5D5i+86x7Ku0v2CUFICT6AUPSl9+FTPiexlL4FdmvQV2CnGTSUw=="
   "resolved" "https://registry.npmjs.org/@angular/router/-/router-13.3.12.tgz"
   "version" "13.3.12"
@@ -306,9 +306,10 @@
   dependencies:
     "tslib" "^2.3.0"
 
-"@auscope/portal-core-ui@file:../portal-core-ui-app/dist/portal-core-ui":
-  "resolved" "file:../portal-core-ui-app/dist/portal-core-ui"
-  "version" "0.0.0-watch+1670989006246"
+"@auscope/portal-core-ui@^1.0.61":
+  "integrity" "sha512-YuIOC4DZ8H8q60rri1R/Xfi1d3JunhxHE3hgcdvVGrLDC2Qbcf3rhIYl90YrSWdh5KicctdCCWZwsjd+2z7w1Q=="
+  "resolved" "https://registry.npmjs.org/@auscope/portal-core-ui/-/portal-core-ui-1.0.61.tgz"
+  "version" "1.0.61"
   dependencies:
     "tslib" "^2.4.1"
 
@@ -2861,7 +2862,7 @@
   "resolved" "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
   "version" "0.12.0"
 
-"cesium@>= 1.93.0", "cesium@1.93":
+"cesium@>= 1.93.0", "cesium@1.93", "cesium@1.93.0":
   "integrity" "sha512-y5+KkISn3+0MZxGj96mNaZc5LAfpiOs1fmZCInH2xHwYw43FaaRbvdSHXZs8OwJ5dZIlo/m1biMyOKr354L+UA=="
   "resolved" "https://registry.npmjs.org/cesium/-/cesium-1.93.0.tgz"
   "version" "1.93.0"
@@ -8406,7 +8407,7 @@
   "resolved" "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz"
   "version" "0.1.4"
 
-"when@^3.7.8":
+"when@^3.7.8", "when@~3.7.8":
   "integrity" "sha512-5cZ7mecD3eYcMiCH4wtRPA5iFJZ50BJYDfckI5RRpQiktMiYTcn0ccLTZOvcbBume+1304fQztxeNzNS9Gvrnw=="
   "resolved" "https://registry.npmjs.org/when/-/when-3.7.8.tgz"
   "version" "3.7.8"


### PR DESCRIPTION
In order to reduce calls to CSW registries, the data search panel will no longer be populated with a full registry search by default, the user will now need to click the search button to initiate a search.