### PR TITLE
changed the TSG Download tab of the NVCL layer to look for cached files

### DIFF
--- a/src/app/modalwindow/querier/customanalytic/nvcl/nvcl.datasetlist.component.html
+++ b/src/app/modalwindow/querier/customanalytic/nvcl/nvcl.datasetlist.component.html
@@ -206,27 +206,31 @@
 					<!-- END tab-pane -->
 					<!-- BEGIN tab-pane -->
 					<div class="tab-pane fade" id="nvcl-card-tab-download-{{nvclDataset.datasetId}}" role="tabpanel">
-						<p>This data is best viewed with the free TSG Base. Available from <a target="_blank" style="color: blue;" href="https://research.csiro.au/thespectralgeologist/tsg/pricing/purchase-tsg/">here</a></p>
-						<form >
-							<div class="form-group  form-group-sm">
-								<label>EMAIL:</label>
-								<input type="text" class="form-control form-control-sm" [(ngModel)]="downloadEmail" name="email" ngModel #email="ngModel" required
-								 pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,3}$">
-								<span class="validity" *ngIf="!email.valid && email.touched"></span>
-							</div>
-						</form>
-						<div class="float-left">
-							<div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
-								<div class="btn-group">
-									<button type="button" class="btn btn-info btn-xs" (click)="downloadTSG(nvclDataset.datasetId)"><i *ngIf="downloadingTSG"
-										class="fa fa-spinner fa-spin fa-fw"></i>Prepare Tsg Dataset</button>
+						<p>This data is best viewed with the <a target="_blank" style="color: blue;" href="https://research.csiro.au/thespectralgeologist/tsg/pricing/purchase-tsg/">free TSG Base.</a></p>
+						<a *ngIf="nvclDataset.TSGCacheDownloadurl" class="float-right btn btn-info btn-xs" href="{{nvclDataset.TSGCacheDownloadurl}}" title="Download TSG file from cache" >Download Immediately from the NVCL File Cache</a>
+						<div *ngIf="!nvclDataset.TSGCacheDownloadurl">
+							<p>Unfortunately, this dataset is not available in the NVCL cache.  You can request it from the State/Territory servers via the form below, but it might take some time to prepare.  Alternatively, you can check other datasets as over 99% are available via the cache.</p>
+							<form >
+								<div class="form-group  form-group-sm">
+									<label>Email:</label>
+									<input type="text" class="form-control form-control-sm" [(ngModel)]="downloadEmail" name="email" ngModel
+										#email="ngModel" required pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,3}$">
+									<span class="validity" *ngIf="!email.valid && email.touched"></span>
 								</div>
-								<div class="btn-group">
-									<button type="button" class="btn btn-info btn-xs" (click)="checkStatus()" [disabled]="!downloadEmail"><i *ngIf="checkingTSG"
-										class="fa fa-spinner fa-spin fa-fw"></i>Check status</button>
+							</form>
+							<div class="float-right">
+								<div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
+									<div class="btn-group">
+										<button type="button" class="btn btn-info btn-xs" (click)="downloadTSG(nvclDataset.datasetId)"><i
+												*ngIf="downloadingTSG" class="fa fa-spinner fa-spin fa-fw"></i>Prepare Tsg Dataset</button>
+									</div>
+									<div class="btn-group">
+										<button type="button" class="btn btn-info btn-xs" (click)="checkStatus()" [disabled]="!downloadEmail"><i
+												*ngIf="checkingTSG" class="fa fa-spinner fa-spin fa-fw"></i>Check status</button>
+									</div>
 								</div>
+								<div [innerHTML]="downloadResponse | trustResourceHtml"></div>
 							</div>
-							<div [innerHTML]="downloadResponse | trustResourceHtml"></div>
 						</div>
 					</div>
 					<!-- BEGIN tab-pane -->

--- a/src/app/modalwindow/querier/customanalytic/nvcl/nvcl.datasetlist.component.ts
+++ b/src/app/modalwindow/querier/customanalytic/nvcl/nvcl.datasetlist.component.ts
@@ -114,11 +114,14 @@ export class NVCLDatasetListComponent implements OnInit {
         nvclDataset.image = true;
         nvclDataset.scalar = false;
         nvclDataset.download = false;
+        nvclDataset.TSGCacheDownloadurl="";
         if (this.nvclBoreholeAnalyticService.hasSavedEmail()) {
           this.downloadEmail = this.nvclBoreholeAnalyticService.getUserEmail();
         }
         this._getNVCLImage(this.onlineResource.url, nvclDataset.datasetId, null);
         this._getNVCLScalar(this.onlineResource.url, nvclDataset.datasetId);
+        this.isCachedTSGFileAvailable(nvclDataset);
+
         this.nvclDatasets.push(nvclDataset);
       }
       if (result.length === 0) {
@@ -287,6 +290,16 @@ export class NVCLDatasetListComponent implements OnInit {
     } else {
       this.selectedLogNames = [];
     }
+  }
+
+  public isCachedTSGFileAvailable(dataset: any) {
+    this.nvclService.getTSGCachedDownloadUrl(this.onlineResource.url, dataset.datasetName).
+      subscribe(url => {
+        dataset.TSGCacheDownloadurl = url;
+      },
+      () => {
+        // swallow error.  the file just isnt cached.
+      });
   }
 
   public downloadCSV(datasetId: string) {


### PR DESCRIPTION
changed the TSG Download tab of the NVCL layer to look for cached files in the NVCL file cache.  If it finds one it will offer the user the direct download.  If not it will show the normal "request from the state/territory" display.  To test this click almost any NVCL hole and go to "Analytic" -> "Download".  you should see the working download link.  To test what happens when there is no file available filter for provider NT and name = 81NB1 . You should see the old download form displayed.