### PR TITLE
AUS-3917 Layer Reordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@angular/platform-server": "^13.3.11",
     "@angular/router": "^13.3.11",
     "@auscope/angular-cesium": "^13.0.1",
-    "@auscope/portal-core-ui": "^1.1.2",
+    "@auscope/portal-core-ui": "^1.1.4",
     "@ng-bootstrap/ng-bootstrap": "^12.1.2",
     "@ng-select/ng-select": "^8.3.0",
     "@popperjs/core": "^2.11.6",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -91,6 +91,7 @@ import { SearchService } from './services/search/search.service';
 import { BoundsService } from './services/bounds/bounds.service';
 import { GraceService } from './services/wcustom/grace/grace.service';
 import { LegendUiService } from './services/legend/legend-ui.service';
+import { LayerManagerService } from './services/ui/layer-manager.service';
 
 import * as PlotlyJS from 'plotly.js-dist-min/plotly.min.js';
 import { PlotlyModule } from 'angular-plotly.js';
@@ -172,7 +173,7 @@ PlotlyModule.plotlyjs = PlotlyJS;
     ],
     providers: [ AuscopeApiService, FilterService, RectanglesEditorService, AdvancedComponentService, SearchService,
                  NVCLService, MSCLService, BoundsService, GraceService, { provide: SAVER, useFactory: getSaver },
-                 LegendUiService, UserStateService, AuthGuard, AuthService
+                 LegendUiService, UserStateService, LayerManagerService, AuthGuard, AuthService
     ],
     imports: [
         PortalCoreModule.forRoot(environment, config),

--- a/src/app/cesium-map/csmap.component.ts
+++ b/src/app/cesium-map/csmap.component.ts
@@ -665,10 +665,9 @@ export class CsMapComponent implements AfterViewInit {
         }, 10);
 
     } else {
-      const activeLayerKeys: string[] = Object.keys(this.csMapService.getLayerModelList());
-      for(const layer of activeLayerKeys) {
-        this.csMapService.setLayerSplitDirection(this.csMapService.getLayerModelList()[layer], SplitDirection.NONE);
-      }
+     for (const layer of this.csMapService.getLayerModelList()) {
+      this.csMapService.setLayerSplitDirection(layer, SplitDirection.NONE);
+     }
     }
   }
 

--- a/src/app/menupanel/activelayers/activelayerspanel.component.html
+++ b/src/app/menupanel/activelayers/activelayerspanel.component.html
@@ -1,34 +1,39 @@
 <div class="select-layers-message" *ngIf="getActiveLayers().length===0">
     Select layers below to add to map
 </div>
-<li *ngFor="let layer of getActiveLayers()">
-    <div class="layerLoadCtrl">
-        <div>
-            <u (click)="openStatusReport(getUILayerModel(layer.id)); $event.stopPropagation();">{{ layer.name }}
-                <span *ngIf="getUILayerModel(layer.id).statusMap.getRenderStarted()" class="float-right project-percentage hasEvent light-blue">
-                    <i *ngIf="!getUILayerModel(layer.id).statusMap.getRenderComplete()" class="fa fa-spin fa-spinner"></i>
-                    <i *ngIf="getUILayerModel(layer.id).statusMap.getContainsError()" class="fa fa-warning text-warning"></i>
-                </span>
-            </u>
-            <i *ngIf="getUILayerModel(layer.id).statusMap.getRenderStarted()" class="fa fa-trash float-right red layerLoadClickable" (click)="removeLayer(layer.id);$event.stopPropagation()"></i>
+<div class="activeLayersBoundary" cdkDropList (cdkDropListDropped)="layerDropped($event)">
+    <li class="activeLayerItem" *ngFor="let layer of getActiveLayers()" cdkDrag cdkDragLockAxis="y" cdkDragBoundary=".activeLayersBoundary">
+        <div *ngIf="getActiveLayers().length > 1" cdkDragHandle>
+            <i class="activeLayerGrabber fa fa-arrows-v" title="Drag to reorder"></i>
         </div>
-        <div *ngIf="showOpacitySlider(layer) && getUILayerModel(layer.id).statusMap.getRenderStarted()" class="opacity-slider-panel d-flex" (click)="$event.stopPropagation()">
-            <div class="opacity-label">Opacity {{ getUILayerModel(layer.id).opacity }}%&nbsp;</div>
-            <mat-slider [min]="0" [max]="100" class="opacity-slider flex-grow-1" [(ngModel)]="getUILayerModel(layer.id).opacity" (input)="layerOpacityChange($event, layer)"></mat-slider>
-            <div *ngIf="hasLegend(layer)">
-                <button class="btn btn-primary btn-sm pull-right" style="margin-left:5px;margin-top:6px;font-size:0.8rem;padding:0 2px;" [disabled]="isLegendShown(layer.id)" (click)="showLegend(layer)">Legend</button>
+        <div class="activeLayerContent">
+            <div>
+                <u style="cursor:pointer;" (click)="openStatusReport(getUILayerModel(layer.id)); $event.stopPropagation();">{{ layer.name }}
+                    <span *ngIf="getUILayerModel(layer.id).statusMap.getRenderStarted()" class="float-right project-percentage hasEvent light-blue">
+                        <i *ngIf="!getUILayerModel(layer.id).statusMap.getRenderComplete()" class="fa fa-spin fa-spinner"></i>
+                        <i *ngIf="getUILayerModel(layer.id).statusMap.getContainsError()" class="fa fa-warning text-warning"></i>
+                    </span>
+                </u>
+                <i *ngIf="getUILayerModel(layer.id).statusMap.getRenderStarted()" class="fa fa-trash float-right red layerLoadClickable" (click)="removeLayer(layer);$event.stopPropagation()"></i>
+            </div>
+            <div *ngIf="showOpacitySlider(layer) && getUILayerModel(layer.id).statusMap.getRenderStarted()" class="opacity-slider-panel d-flex" (click)="$event.stopPropagation()">
+                <div class="opacity-label">Opacity {{ getUILayerModel(layer.id).opacity }}%&nbsp;</div>
+                <mat-slider [min]="0" [max]="100" class="opacity-slider flex-grow-1" [(ngModel)]="getUILayerModel(layer.id).opacity" (input)="layerOpacityChange($event, layer)"></mat-slider>
+                <div *ngIf="hasLegend(layer)">
+                    <button class="btn btn-primary btn-sm pull-right" style="margin-left:5px;margin-top:6px;font-size:0.8rem;padding:0 2px;" [disabled]="isLegendShown(layer.id)" (click)="showLegend(layer)">Legend</button>
+                </div>
+            </div>
+            <div class="split-panel" *ngIf="getShowSplitMapButtons(layer)" (click)="$event.stopPropagation()">
+                Split Direction&nbsp;
+                <div *ngIf="getApplicableSplitLayer(layer)" class="split-button-panel">
+                    <button [className]="getLayerSplitDirection(layer.id) === 'left' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'left')">Left</button>
+                    <button [className]="getLayerSplitDirection(layer.id) === 'none' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'none')">Both</button>
+                    <button [className]="getLayerSplitDirection(layer.id) === 'right' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'right')">Right</button>
+                </div>
+                <div *ngIf="!getApplicableSplitLayer(layer)" class="split-button-panel">
+                    <button class="btn btn-split btn-primary" [disabled]="true">Layer not supported</button>
+                </div>
             </div>
         </div>
-        <div class="split-panel" *ngIf="getShowSplitMapButtons(layer)" (click)="$event.stopPropagation()">
-            Split Direction&nbsp;
-            <div *ngIf="getApplicableSplitLayer(layer)" class="split-button-panel">
-                <button [className]="getLayerSplitDirection(layer.id) === 'left' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'left')">Left</button>
-                <button [className]="getLayerSplitDirection(layer.id) === 'none' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'none')">Both</button>
-                <button [className]="getLayerSplitDirection(layer.id) === 'right' ? 'btn btn-split btn-primary' : 'btn btn-split btn-warning'" (click)="setLayerSplitDirection($event, layer, 'right')">Right</button>
-            </div>
-            <div *ngIf="!getApplicableSplitLayer(layer)" class="split-button-panel">
-                <button class="btn btn-split btn-primary" [disabled]="true">Layer not supported</button>
-            </div>
-        </div>
-    </div>
-</li>
+    </li>
+</div>

--- a/src/app/menupanel/activelayers/activelayerspanel.component.scss
+++ b/src/app/menupanel/activelayers/activelayerspanel.component.scss
@@ -1,0 +1,43 @@
+.activeLayerItem {
+  display: flex;
+  position: relative;
+  right: 5px;
+  width: 100%;
+  align-items: center;
+  font-size: .85rem;
+  color: #d8d9d7;
+  margin: 0 5px 0 0;
+
+  // Disbale text selection
+  -webkit-user-select: none;  /* Safari */
+  -ms-user-select: none;      /* IE 10 and IE 11 */
+  user-select: none;          /* Standard syntax */
+
+  .activeLayerGrabber {
+    cursor: grab;
+    margin-right: 0.5em;
+    border: 1px solid white;
+    border-radius: 0.5em;
+    padding: 0.2em 0.4em;
+  }
+
+  .activeLayerContent {
+    width:100%;
+  }
+}
+
+
+.cdk-drag-preview {
+  background-color: #6764ce;
+  color: #d8d9d7;
+  box-sizing: border-box;
+  border: 1px solid white;
+  border-radius: 4px;
+  box-shadow: 0 5px 5px -3px rgba(0, 0, 0, 0.2),
+              0 8px 10px 1px rgba(0, 0, 0, 0.14),
+              0 3px 14px 2px rgba(0, 0, 0, 0.12);
+}
+
+.cdk-drop-list-dragging {
+  cursor: grabbing;
+}

--- a/src/app/menupanel/activelayers/activelayerspanel.component.ts
+++ b/src/app/menupanel/activelayers/activelayerspanel.component.ts
@@ -6,33 +6,29 @@ import { UILayerModel } from '../common/model/ui/uilayer.model';
 import { UILayerModelService } from 'app/services/ui/uilayer-model.service';
 import { BsModalService, BsModalRef } from 'ngx-bootstrap/modal';
 import { NgbdModalStatusReportComponent } from '../../toppanel/renderstatus/renderstatus.component';
-import { AdvancedComponentService } from 'app/services/ui/advanced-component.service';
 import { LegendUiService } from 'app/services/legend/legend-ui.service';
+import { CdkDragDrop } from '@angular/cdk/drag-drop';
+import { LayerManagerService } from 'app/services/ui/layer-manager.service';
 
 @Component({
   selector: '[appActiveLayers]',
   templateUrl: './activelayerspanel.component.html',
-  styleUrls: ['../menupanel.scss']
+  styleUrls: ['../menupanel.scss', './activelayerspanel.component.scss']
 })
 export class ActiveLayersPanelComponent {
   bsModalRef: BsModalRef;
 
   constructor(private csMapService: CsMapService,
     private uiLayerModelService: UILayerModelService, private layerHandlerService: LayerHandlerService,
-    private advancedComponentService: AdvancedComponentService, private legendUiService: LegendUiService,
+    private layerManagerService: LayerManagerService, private legendUiService: LegendUiService,
     private modalService: BsModalService) { }
 
   /**
    * Get active layers
    */
   public getActiveLayers(): LayerModel[] {
-    const activeLayers: LayerModel[] = [];
-    const activeLayerKeys: string[] = Object.keys(this.csMapService.getLayerModelList());
-    for (const layer of activeLayerKeys) {
-      const currentLayer = this.csMapService.getLayerModelList()[layer];
-      activeLayers.push(currentLayer);
-    }
-    return activeLayers;
+    const reversedLayers = [...this.csMapService.getLayerModelList()].reverse();
+    return reversedLayers;
   }
 
   /**
@@ -48,14 +44,8 @@ export class ActiveLayersPanelComponent {
    *
    * @layerId layerId ID of LayerModel
    */
-  removeLayer(layerId: string): void {
-    const layerModelList = this.csMapService.getLayerModelList();
-    if (layerModelList.hasOwnProperty(layerId)) {
-      this.csMapService.removeLayer(layerModelList[layerId]);
-      // Remove any layer specific components
-      this.advancedComponentService.removeAdvancedMapComponents(layerId);
-    }
-    this.legendUiService.removeLegend(layerId);
+  removeLayer(layer: LayerModel): void {
+    this.layerManagerService.removeLayer(layer);
     // Remove polygon filter if was opened and no layers present
     /*
     if (Object.keys(layerModelList).length === 0) {
@@ -121,7 +111,7 @@ export class ActiveLayersPanelComponent {
    */
   public getLayerSplitDirection(layerId: string): string {
     let splitDir = "none";
-    if (this.csMapService.getLayerModel(layerId) !== null) {
+    if (this.csMapService.getLayerModel(layerId) !== undefined) {
       switch(this.csMapService.getLayerModel(layerId).splitDirection) {
         case SplitDirection.LEFT:
           splitDir = "left";
@@ -197,6 +187,19 @@ export class ActiveLayersPanelComponent {
    */
   public isLegendShown(layerId: string): boolean {
     return this.legendUiService.isLegendDisplayed(layerId);
+  }
+
+  /**
+   * Event fired when a LayerModel has been been dropped after being dragged
+   * @param event the CdkDragDrop event
+   */
+  public layerDropped(event: CdkDragDrop<LayerModel[]>) {
+    // Active layers list was reversed so invert array indices
+    const fromIndex = this.getActiveLayers().length - event.previousIndex - 1;
+    const toIndex = this.getActiveLayers().length - event.currentIndex - 1;
+    if (fromIndex !== toIndex) {
+      this.csMapService.moveLayer(fromIndex, toIndex);
+    }
   }
 
 }

--- a/src/app/menupanel/cataloguesearch/cataloguesearch.component.ts
+++ b/src/app/menupanel/cataloguesearch/cataloguesearch.component.ts
@@ -1,8 +1,4 @@
-import { Bbox } from '@auscope/portal-core-ui';
-import { LayerModel } from '@auscope/portal-core-ui';
-import { CsMapService } from '@auscope/portal-core-ui';
-import { RenderStatusService } from '@auscope/portal-core-ui';
-import { UtilitiesService } from '@auscope/portal-core-ui';
+import { Bbox, CsMapService, LayerModel, RenderStatusService, UtilitiesService } from '@auscope/portal-core-ui';
 import { NgbdModalStatusReportComponent } from '../../toppanel/renderstatus/renderstatus.component';
 import { UILayerModel } from '../common/model/ui/uilayer.model';
 import { CataloguesearchService } from './cataloguesearch.service';
@@ -10,7 +6,7 @@ import { Component, AfterViewInit } from '@angular/core';
 import { BsModalService, BsModalRef } from 'ngx-bootstrap/modal';
 import { RectangleEditorObservable } from '@auscope/angular-cesium';
 import { UILayerModelService } from 'app/services/ui/uilayer-model.service';
-import { LegendUiService } from 'app/services/legend/legend-ui.service';
+import { LayerManagerService } from 'app/services/ui/layer-manager.service';
 
 
 @Component({
@@ -43,7 +39,7 @@ export class CatalogueSearchComponent implements AfterViewInit {
 
   constructor(private csMapService: CsMapService, private cataloguesearchService: CataloguesearchService,
               private renderStatusService: RenderStatusService,  private modalService: BsModalService,
-              private uiLayerModelService: UILayerModelService, private legedUiService: LegendUiService) {
+              private layerManagerService: LayerManagerService, private uiLayerModelService: UILayerModelService) {
     this.drawStarted = false;
     this.searchMode = true;
     this.loading = false;
@@ -186,8 +182,7 @@ export class CatalogueSearchComponent implements AfterViewInit {
    * remove a layer from the map
    */
   public removeLayer(layer: LayerModel) {
-    this.csMapService.removeLayer(layer);
-    this.legedUiService.removeLegend(layer.id);
+    this.layerManagerService.removeLayer(layer);
   }
 
   /**

--- a/src/app/menupanel/clipboard/clipboard.component.ts
+++ b/src/app/menupanel/clipboard/clipboard.component.ts
@@ -23,7 +23,7 @@ export class ClipboardComponent {
   }
 
   public getActiveLayerCount(): number {
-    return Object.keys(this.csMapService.getLayerModelList()).length;
+    return this.csMapService.getLayerModelList().length;
   }
 
 }

--- a/src/app/menupanel/common/model/ui/uilayer.model.ts
+++ b/src/app/menupanel/common/model/ui/uilayer.model.ts
@@ -6,18 +6,18 @@ import { BehaviorSubject } from 'rxjs';
  * a representation of the state of the panel component in the expanded panel.
  */
 export class UILayerModel {
-    expanded: boolean;
-    tabpanel: UITabPanel;
-    statusMap: StatusMapModel;
-    opacity: number;
+  expanded: boolean;
+  tabpanel: UITabPanel;
+  statusMap: StatusMapModel;
+  opacity: number;
 
-   constructor(public id: string, public loadingSubject: BehaviorSubject<StatusMapModel>) {
+  constructor(public id: string, public loadingSubject: BehaviorSubject<StatusMapModel>) {
     this.tabpanel = new UITabPanel();
     this.expanded = false;
     this.opacity = 100;
     loadingSubject.subscribe((value) => {
       this.statusMap = value;
     });
-   }
+  }
 
 }

--- a/src/app/menupanel/custompanel/layergroup.component.ts
+++ b/src/app/menupanel/custompanel/layergroup.component.ts
@@ -1,10 +1,10 @@
 import { Component, Input } from '@angular/core';
-import { CsMapService, LayerModel } from '@auscope/portal-core-ui';
+import { LayerModel } from '@auscope/portal-core-ui';
 import { UILayerModel } from '../common/model/ui/uilayer.model';
 import { UILayerModelService } from 'app/services/ui/uilayer-model.service';
 import { InfoPanelComponent } from '../common/infopanel/infopanel.component';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-import { LegendUiService } from 'app/services/legend/legend-ui.service';
+import { LayerManagerService } from 'app/services/ui/layer-manager.service';
 
 
 @Component({
@@ -17,8 +17,8 @@ export class LayerGroupComponent {
   // Contains the layers on display 
   @Input() layerGroups: { 'Results': LayerModel[] };
 
-  constructor(private csMapService: CsMapService, private uiLayerModelService: UILayerModelService,
-    private legendUiService: LegendUiService, public activeModalService: NgbModal) {
+  constructor(private uiLayerModelService: UILayerModelService, private layerManagerService: LayerManagerService,
+    public activeModalService: NgbModal) {
   }
 
   /**
@@ -36,8 +36,7 @@ export class LayerGroupComponent {
    * @param layer layer to be removed
    */
   public removeLayer(layer: LayerModel) {
-    this.csMapService.removeLayer(layer);
-    this.legendUiService.removeLegend(layer.id);
+    this.layerManagerService.removeLayer(layer);
   }
 
   /**

--- a/src/app/menupanel/data-explorer-record/data-explorer-record.component.html
+++ b/src/app/menupanel/data-explorer-record/data-explorer-record.component.html
@@ -11,7 +11,7 @@
             <i class="fa fa-plus-circle" style="color:green;"></i>
         </button>            
         <button *ngIf="csMapService.layerExists(cswRecord.id)" class="btn btn-sm btn-outline-secondary" data-toggle="tooltip" title="Remove layer from map"
-            (click)="removeLayer(layer.id)">
+            (click)="removeLayer(layer)">
             <i class="fa fa-trash" style="color:red;"></i>
         </button>        
     </span>

--- a/src/app/services/ui/layer-manager.service.ts
+++ b/src/app/services/ui/layer-manager.service.ts
@@ -1,0 +1,129 @@
+import { Injectable } from '@angular/core';
+import { CsMapService, LayerModel, ManageStateService } from '@auscope/portal-core-ui';
+import { AdvancedComponentService } from './advanced-component.service';
+import { LegendUiService } from '../legend/legend-ui.service';
+import { UILayerModelService } from './uilayer-model.service';
+import { environment } from 'environments/environment';
+import * as _ from 'lodash';
+import * as $ from 'jquery';
+
+declare let gtag: Function;
+
+/**
+ * Class for managing the addition and removal of map layers.
+ */
+@Injectable()
+export class LayerManagerService {
+
+  constructor(private csMapService: CsMapService, private manageStateService: ManageStateService, private uiLayerModelService: UILayerModelService,
+              private advancedComponentService: AdvancedComponentService, private legendUiService: LegendUiService) {}
+
+
+  /**
+   * Add a layer
+   *
+   * @param layer
+   * @param optionalFilters
+   * @param layerFilterCollection
+   * @param layerTime
+   *
+   * TODO: FilterPanel is only place bounding box filter can currently be set, better to shift flag to FilterService
+   * and apply here when it's needed to adding from SearchPanel etc. will apply filter as well
+   */
+  public addLayer(layer: LayerModel, optionalFilters: Array<Object>, layerFilterCollection: any, layerTime: Date) {
+    if (environment.googleAnalyticsKey && typeof gtag === 'function') {
+      gtag('event', 'Addlayer', {
+        event_category: 'Addlayer',
+        event_action: 'AddLayer:' + layer.id
+      });
+    }
+    const param = {
+      optionalFilters: _.cloneDeep(optionalFilters)
+    };
+
+    if (layerTime) {
+      param['time'] = layerTime;
+    }
+
+    // Get AdvancedFilter params if applicable
+    let advancedFilterParams = null;
+    const advancedFilter = this.advancedComponentService.getAdvancedFilterComponentForLayer(layer.id);
+    if (advancedFilter) {
+      advancedFilterParams = advancedFilter.getAdvancedParams();
+      // Append any call parameters the AdvancedFilter may add
+      Object.assign(param, advancedFilter.getCallParams());
+    }
+
+    // Remove filters without values
+    param.optionalFilters = param.optionalFilters.filter(f => this.filterHasValue(f));
+    for (const optFilter of param.optionalFilters) {
+      if (optFilter['options']) {
+        optFilter['options'] = [];
+      }
+    }
+
+    // Add a new layer in the layer state service
+    this.manageStateService.addLayer(
+      layer.id,
+      layerTime,
+      layerFilterCollection,
+      optionalFilters,
+      advancedFilterParams
+    );
+
+    // Remove any existing legends in case map re-added with new style
+    this.legendUiService.removeLegend(layer.id);
+
+    // Add layer to map in Cesium
+    this.csMapService.addLayer(layer, param);
+
+    // If on a small screen, when a new layer is added, roll up the sidebar to expose the map */
+    if ($('#sidebar-toggle-btn').css('display') !== 'none') {
+      $('#sidebar-toggle-btn').click();
+    }
+
+    // Add any advanced map components defined in refs.ts
+    this.advancedComponentService.addAdvancedMapComponents(layer);
+  }
+
+  /**
+   * Remove a layer. Removes from map, resets opacity, and removes advanced map components and legends
+   * @param layer the layer to remove
+   */
+  public removeLayer(layer: LayerModel) {
+    // Reset opacity to 100, mainly so UI resets and matches layer if re-added later
+    // TODO: we should keep as is and use it when re-added
+    const uiLayerModel = this.uiLayerModelService.getUILayerModel(layer.id);
+    if (uiLayerModel) {
+      uiLayerModel.opacity = 100;
+      this.uiLayerModelService.setUILayerModel(layer.id, uiLayerModel);
+    }
+    //
+    this.csMapService.removeLayer(layer);
+    // Remove any layer specific map components
+    this.advancedComponentService.removeAdvancedMapComponents(layer.id);
+    this.legendUiService.removeLegend(layer.id);
+  }
+
+  /**
+   * Test if a filter contains a value. This means non-null for all filters, with the added
+   * requirement for OPTIONAL.PROVIDER filters that at least one value in the list be true
+   * @param filter the filter to test
+   * @returns true if the filter contains a valid value
+   */
+  private filterHasValue(filter: Object): boolean {
+    let hasValue = false;
+    if (filter['type'] === 'OPTIONAL.PROVIDER') {
+      for (const provider in filter['value']) {
+        if (filter['value'][provider] === true) {
+          hasValue = true;
+          break;
+        }
+      }
+    } else if (filter['value'] !== null) {
+      hasValue = true;
+    }
+    return hasValue;
+  }
+
+}


### PR DESCRIPTION
 Allow layer reordering with drag and drop in the ActiveLayersPanel.
Layer order is now preserved in states and layers should load in the same order they were saved.
Adding/removing layers pushed to a new LayerManagerService class so code is consistent wherever this happens.
Layers that are re-added are pushed to the top of the ActiveLayers list so layer order is maintained.