### PR TITLE
AUS-3942 GRACE state load values

### DIFF
--- a/src/app/menupanel/common/filterpanel/advance/grace/grace-advanced-filter.component.ts
+++ b/src/app/menupanel/common/filterpanel/advance/grace/grace-advanced-filter.component.ts
@@ -132,6 +132,7 @@ import { GraceStyleSettings } from 'app/modalwindow/querier/customanalytic/grace
      * @returns current style settings
      */
     public getAdvancedParams(): GraceStyleSettings {
+        this.graceService.setCurrentGraceStyleSettings(this.graceService.editedGraceStyleSettings);
         return this.graceService.currentGraceStyleSettings;
     }
 

--- a/src/app/services/ui/layer-manager.service.ts
+++ b/src/app/services/ui/layer-manager.service.ts
@@ -18,7 +18,6 @@ export class LayerManagerService {
   constructor(private csMapService: CsMapService, private manageStateService: ManageStateService, private uiLayerModelService: UILayerModelService,
               private advancedComponentService: AdvancedComponentService, private legendUiService: LegendUiService) {}
 
-
   /**
    * Add a layer
    *
@@ -62,6 +61,12 @@ export class LayerManagerService {
       }
     }
 
+    // Remove any existing legends in case map re-added with new style
+    this.legendUiService.removeLegend(layer.id);
+
+    // Add layer to map in Cesium
+    this.csMapService.addLayer(layer, param);
+
     // Add a new layer in the layer state service
     this.manageStateService.addLayer(
       layer.id,
@@ -70,12 +75,6 @@ export class LayerManagerService {
       optionalFilters,
       advancedFilterParams
     );
-
-    // Remove any existing legends in case map re-added with new style
-    this.legendUiService.removeLegend(layer.id);
-
-    // Add layer to map in Cesium
-    this.csMapService.addLayer(layer, param);
 
     // If on a small screen, when a new layer is added, roll up the sidebar to expose the map */
     if ($('#sidebar-toggle-btn').css('display') !== 'none') {


### PR DESCRIPTION
Fixed issue with state values not being persisted for GRACE layer.
Fixed bug where adding a state twice would remove it from the ManageStateService's stored state.