### PR TITLE
AUS-3936 Clear bounds issue, plus minor UI tweaks

### DIFF
--- a/src/app/menupanel/common/downloadpanel/downloadpanel.component.ts
+++ b/src/app/menupanel/common/downloadpanel/downloadpanel.component.ts
@@ -387,8 +387,6 @@ export class DownloadPanelComponent implements OnInit {
    */
   public clearBounds(): void {
     this.boundsService.clearBounds();
-    this.wcsDownloadForm = {};
-    this.wcsDownloadListOption = null;
   }
 
   /**

--- a/src/app/menupanel/login/login-menu.component.html
+++ b/src/app/menupanel/login/login-menu.component.html
@@ -7,8 +7,8 @@
             </div>
         </button>
         <mat-menu #loginMenu="matMenu" style="margin-top:12px;">
-            <h5 *ngIf="userHasStates()" mat-menu-item><button (click)="manageStates()" class="btn user-button"><i class="ti-link"></i>&nbsp;&nbsp;Manage Permanent Links</button></h5>
-            <h5 mat-menu-item><button (click)="logOut()" class="btn user-button"><i class="fa fa-power-off"></i>&nbsp;&nbsp;Log Out</button></h5>
+            <h5 *ngIf="userHasStates()" mat-menu-item (click)="manageStates()"><i class="ti-link"></i>&nbsp;&nbsp;Manage Permanent Links</h5>
+            <h5 mat-menu-item (click)="logOut()"><i class="fa fa-power-off"></i>&nbsp;&nbsp;Log Out</h5>
         </mat-menu>
     </div>
     <div *ngIf="!user">

--- a/src/app/modalwindow/querier/customanalytic/nvcl/nvcl.datasetlist.component.ts
+++ b/src/app/modalwindow/querier/customanalytic/nvcl/nvcl.datasetlist.component.ts
@@ -274,6 +274,7 @@ export class NVCLDatasetListComponent implements OnInit {
         this.selectedLogNames[datasetId] = logNames;
         if (logIds.length <= 0) {
           alert('No logs selected');
+          return;
         }
 
         setTimeout(() => {
@@ -309,6 +310,7 @@ export class NVCLDatasetListComponent implements OnInit {
 
     if (logIds.length <= 0) {
       alert('No logs selected');
+      return;
     }
     this.nvclService.getNVCL2_0_CSVDownload(this.onlineResource.url, logIds).
       subscribe(response => {

--- a/src/app/modalwindow/querier/querier.modal.component.html
+++ b/src/app/modalwindow/querier/querier.modal.component.html
@@ -31,7 +31,7 @@
 					<div class="card-header">
 						<h4 class="card-title">
 							<a (click)="transformToHtml(doc)" *ngIf="doc.node_name !== null" class="accordion-link" data-toggle="collapse" href="#doc-collapse{{i}}">
-								{{doc.layer.name}} : {{doc.node_name}}&nbsp;<i *ngIf="transformingToHtml[doc.key] && doc.expanded" class="fa fa-spinner fa-spin"></i>
+								{{doc.layer.name}}{{doc.node_name ? ': ' + doc.node_name : ''}}&nbsp;<i *ngIf="transformingToHtml[doc.key] && doc.expanded" class="fa fa-spinner fa-spin"></i>
 							</a>
 							<a (click)="transformToHtml(doc)" *ngIf="doc.node_name === null" class="accordion-link" data-toggle="collapse" href="#doc-collapse{{i}}">
 								{{doc.layer.name}}&nbsp;<i *ngIf="transformingToHtml[doc.key] && doc.expanded" class="fa fa-spinner fa-spin"></i>

--- a/src/app/modalwindow/querier/querier.modal.component.ts
+++ b/src/app/modalwindow/querier/querier.modal.component.ts
@@ -153,7 +153,6 @@ export class QuerierModalComponent  implements OnInit {
     });
   }
 
-
   /**
    * Copy drawn polygon to clipboard
    * @param document polygon as document
@@ -185,32 +184,37 @@ export class QuerierModalComponent  implements OnInit {
 
   // Look for changes and update UI after brief delay
   public onDataChange(): void {
-    let htmldata = []
-    let Expression=/http(s)?:\/\/([\w-]+\.)+[\w-]+(\/[\w- .\/?%&=]*)?/;
-    let objExp=new RegExp(Expression);
+    const htmldata = []
+    const Expression = /http(s)?:\/\/([\w-]+\.)+[\w-]+(\/[\w- .\/?%&=]*)?/;
+    const objExp = new RegExp(Expression);
     for (let  i = 0; i < this.docs.length; i++) {
-      var doc = new DOMParser().parseFromString(this.docs[i].raw, "text/xml");
+      const doc = new DOMParser().parseFromString(this.docs[i].raw, 'text/xml');
       if (doc.getElementsByTagName('gml:name').length != 0) {
-        for (let html in doc.getElementsByTagName('gml:name')) {
+        for (const html in doc.getElementsByTagName('gml:name')) {
           if(!objExp.test(doc.getElementsByTagName('gml:name')[html].innerHTML)) {
             htmldata.push(doc.getElementsByTagName('gml:name')[html].innerHTML)
           }
         }
+      } else if (doc.getElementsByTagName('gml:NAME').length != 0) {
+        for (const html in doc.getElementsByTagName('gml:NAME')) {
+          if(!objExp.test(doc.getElementsByTagName('gml:NAME')[html].innerHTML)) {
+            htmldata.push(doc.getElementsByTagName('gml:NAME')[html].innerHTML)
+          }
+        }
       } else if (doc.getElementsByTagName('gsmlp:name').length != 0) {
-        for (let html in doc.getElementsByTagName('gsmlp:name')) {
+        for (const html in doc.getElementsByTagName('gsmlp:name')) {
           if(!objExp.test(doc.getElementsByTagName('gsmlp:name')[html].innerHTML)) {
             htmldata.push(doc.getElementsByTagName('gsmlp:name')[html].innerHTML)
           }
         }
       } else if (doc.getElementsByTagName('null:name').length != 0) {
-        for (let html in doc.getElementsByTagName('null:name')) {
+        for (const html in doc.getElementsByTagName('null:name')) {
           if(!objExp.test(doc.getElementsByTagName('null:name')[html].innerHTML)) {
             htmldata.push(doc.getElementsByTagName('null:name')[html].innerHTML)
           }
         }
       }
       this.docs[i]['node_name'] = htmldata[i]
-
     }
     setTimeout(() => {
       this.changeDetectorRef.detectChanges();
@@ -223,7 +227,6 @@ export class QuerierModalComponent  implements OnInit {
    * @param document
    */
   public transformToHtml(document): void {
-
     if (this.msclService.usesGMLObs(document.raw)) {
       this.hasMsclAnalytics = true;
     }
@@ -269,15 +272,13 @@ export class QuerierModalComponent  implements OnInit {
       document.loadSubComponent = true;
       this.transformingToHtml[document.key] = false;
       this.changeDetectorRef.detectChanges();
-    },
-    // try default XML tree display
-    error => {
+    }, () => {
+      // try default XML tree display
       this.parseTree(document);
       this.transformingToHtml[document.key] = false;
       this.changeDetectorRef.detectChanges();
     });
   }
-
 
   /**
    * Parses server response and builds a document tree
@@ -372,7 +373,6 @@ export class QuerierModalComponent  implements OnInit {
     }
     return data;
   }
-
 
   /**
    * Reformats labels to make them more user-friendly


### PR DESCRIPTION
- Fixed issue where pressing the Clear Bounds button on the download panel would clear all the download options from the download panel (e.g. Aster layers, refer to https://jira.csiro.au/browse/AUS-3936).
- Features on the QuerierModal component that do not have a node name no longer show a ":" character (e.g. "Mine View : <blank>").
- Node names now also look for the XML element "gml:NAME", so Geological Provinces names should now appear in the QuerierModal window.
- A few NVCL functions are now returned to prevent errors when required information is not present.