### PR TITLE
load context before google analytics

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,20 +6,33 @@ import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 import { ContextService, ContextConfig, CONTEXT_CONFIG } from "@csiro-geoanalytics/ng";
 
-if (environment.production) {
-  enableProdMode();
-}
+ContextService.load()
+	.then(context => {
+		/*
+			each property of the context file is copied over to the environment object, replacing any that share the same name.
+		*/
+		Object.keys(context).forEach(key => environment[key]=context[key]);
 
-if (environment.googleAnalyticsKey) {
-  const gtagscript = document.createElement('script');
-  gtagscript.src = 'https://www.googletagmanager.com/gtag/js?id=' + environment.googleAnalyticsKey;
-  gtagscript.async = true;
-  document.head.appendChild(gtagscript);
-  const gtaginitscript = document.createElement('script');
-  gtaginitscript.innerHTML = 'window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag(\'js\', new Date());gtag(\'config\', \'' +
-  environment.googleAnalyticsKey + '\');';
-  document.head.appendChild(gtaginitscript);
-}
+		if (environment.production) {
+			enableProdMode();
+		  }
+		  
+		  if (environment.googleAnalyticsKey) {
+			const gtagscript = document.createElement('script');
+			gtagscript.src = 'https://www.googletagmanager.com/gtag/js?id=' + environment.googleAnalyticsKey;
+			gtagscript.async = true;
+			document.head.appendChild(gtagscript);
+			const gtaginitscript = document.createElement('script');
+			gtaginitscript.innerHTML = 'window.dataLayer = window.dataLayer || [];function gtag(){dataLayer.push(arguments);}gtag(\'js\', new Date());gtag(\'config\', \'' +
+			environment.googleAnalyticsKey + '\');';
+			document.head.appendChild(gtaginitscript);
+		  }
+
+		return platformBrowserDynamic().bootstrapModule(AppModule)
+	})
+	.catch(err => console.error(err));
+
+
 
 declare var require;
 
@@ -31,13 +44,5 @@ window['CESIUM_BASE_URL'] = '/assets/cesium/';
 	To run the application under a different execution context provide a path to context
 	configuration file into the ContextService.load() method below.  Or just accept the default ./contexts/context.json
 */
-ContextService.load()
-	.then(context => {
-		/*
-			each property of the context file is copied over to the environment object, replacing any that share the same name.
-		*/
-		Object.keys(context).forEach(key => environment[key]=context[key]);
-		return platformBrowserDynamic().bootstrapModule(AppModule)
-	})
-	.catch(err => console.error(err));
+
 


### PR DESCRIPTION
google analytics was starting up before the context had been loaded.  This caused the ga keys entered via the context file to be ignored.  So, I moved the GA init step and enableprodmode to run after the context load.