### PR TITLE
Hide Browse Menu Panels

### DIFF
--- a/src/app/browsepanel/browsepanel.component.html
+++ b/src/app/browsepanel/browsepanel.component.html
@@ -5,7 +5,7 @@
 
 <div *ngIf="bShowBrowsePanel" class="browse-menu">
 	<!-- Layer Groups column -->
-	<div class="container text-left">
+	<div class="container text-left browse-menu-col">
 		<a style="font-weight: bold">Featured Layer Groups</a>
 		<div class="row align-items-start" *ngFor="let layerGroup of layerGroupColumn | keyvalue">
 			<div class="col" (click)="selectGroup(layerGroup)">
@@ -17,7 +17,7 @@
 	</div>
 
 	<!-- Layers column -->
-	<div style="width:100%" class="container text-left">
+	<div [style.display]="layerColumnHeader === '' && !panelStayOpen ? 'none' : 'block'" class="container text-left browse-menu-col">
 		<a *ngIf="!layerColumnHeader" style="font-weight: bold">Layers</a>
 		<a *ngIf="layerColumnHeader"><span style="font-weight: bold;" class="truncate-layer">{{layerColumnHeader}} Layers</span></a>
 		<div class="row align-items-start" *ngFor="let layer of layerColumn">
@@ -34,7 +34,7 @@
 	</div>
 
 	<!-- Info column -->
-	<div style="width:100%" class="info-col">
+	<div [style.display]="selectedLayer || panelStayOpen ? 'block' : 'none'" class="info-col">
 		<a style="font-weight: bold">Information</a>
 		<!-- 'Stay Open' check box -->
 		<div style="float: right;" class="form-check">

--- a/src/app/browsepanel/browsepanel.component.scss
+++ b/src/app/browsepanel/browsepanel.component.scss
@@ -3,8 +3,8 @@
 :host {
 
     .browse-menu {
-        display: grid;
-        grid-template-columns: 300px 340px 420px;
+        display: flex;
+        flex-direction: row;
         position: fixed;
         line-height: 1.2;
         top: 130px;
@@ -15,6 +15,10 @@
         opacity: 0.9;
         border: 1px solid #444444;
         border-radius: .8rem!important;
+
+        .browse-menu-col {
+            flex: fit-content;
+        }
     }
 
     .browse-menu-button {
@@ -77,6 +81,8 @@
     }
 
     .info-col {
+        max-width: 420px;
+        min-width: 420px;
         height: 700px;
         overflow-x: hidden;
         overflow-y: auto;


### PR DESCRIPTION
The relevant browse menu panels will not display when groups and/or layers aren't selected.