### PR TITLE
AUS-4174 Bookmarks and User Logging Out Issue

### DIFF
--- a/src/app/browsepanel/browsepanel.component.ts
+++ b/src/app/browsepanel/browsepanel.component.ts
@@ -100,6 +100,11 @@ export class BrowsePanelComponent implements OnInit, AfterViewInit, OnDestroy {
    * @returns true if user is logged in, false otherwise
    */
   public isUserLoggedIn(): boolean {
+    // If the user logs out showOnlyBookmarked doesn't get reset.
+    // TODO: Whether to show bookmarks should probably be in a service, but this will work for the short term
+    if (!this.authService.isLoggedIn) {
+      this.showOnlyBookmarked = false;
+    }
     return this.authService.isLoggedIn;
   }
 


### PR DESCRIPTION
The check (is the user logged in) to see if the bookmarks checkbox should be displayed will now set the show bookmarks only flag to false if the user is logged out in order to stop all layers disappearing if the flag is true when the user logs out.