### PR TITLE
AUS-4204 Active Layer Names on Single Row

### DIFF
--- a/src/app/menupanel/activelayers/activelayerspanel.component.scss
+++ b/src/app/menupanel/activelayers/activelayerspanel.component.scss
@@ -105,6 +105,7 @@
       margin-right: 2px;
       text-overflow: ellipsis;
       overflow: hidden;
+      white-space: nowrap;
     }
   }
 


### PR DESCRIPTION
Active layer names will only occupy a single row and use ellipses to indicate truncation.