### PR TITLE
AUS-4229 World Map Bounds Cropping

### DIFF
--- a/src/app/menupanel/common/infopanel/subpanel/subpanel.component.ts
+++ b/src/app/menupanel/common/infopanel/subpanel/subpanel.component.ts
@@ -123,8 +123,10 @@ export class InfoPanelSubComponent implements OnInit {
             } else if (this.layer.legendImg && this.layer.legendImg !== '') {
                 this.legendUrl = this.env.portalBaseUrl + 'legend/' + this.layer.legendImg;
             }
-            // Gather up BBOX coordinates to calculate the centre and envelope
-            const bbox = this.cswRecord.geographicElements[0];
+            
+            // Gather up BBOX coordinates to calculate the centre and envelope. Use a copy of coords so they don't stay modified for the main map
+            const bbox = { ...this.cswRecord.geographicElements[0] };
+
             // Make sure that the view is only of Australia
             // On most maps if we use world-wide bounds it will make the Australian features too small
             if (bbox.westBoundLongitude < 100) {


### PR DESCRIPTION
Prevent world-wide layers from being cropped to Australia when added to map after preview has been shown.