### PR TITLE
AUS-4313 Recuce legend modal z-index

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -863,9 +863,9 @@ fieldset.show-fieldset-borders-whitebg legend{
 }
 
 ::ng-deep {
-    // Reduce LegendModal z-index from 1000 to 100 so feature click dialogs aren't obscured
+    // Reduce LegendModal z-index from 1000 to 99 so feature click dialogs and browse/search panels (z: 100) aren't obscured
     .cdk-overlay-container {
-        z-index: 100 !important;
+        z-index: 99 !important;
     }
 }
 /* End LegendModal dialog */


### PR DESCRIPTION
Reduce legend modals' z-index by 1 so as not to obscure browse/search panels.