### PR TITLE
AUS-4409 and AUS-4410 Missing Info button and link opening in same page

### DIFF
--- a/src/app/cesium-map/csmap.component.ts
+++ b/src/app/cesium-map/csmap.component.ts
@@ -545,7 +545,7 @@ export class CsMapComponent implements AfterViewInit {
    * @returns HTML string
    */
   private parseCSWtoHTML(cswRecord: CSWRecordModel): string {
-    let html = '<div class="row"><div class="col-md-3">Source</div><div class="col-md-9"><a style="color: #000000" href="' + cswRecord.recordInfoUrl + '">Full Metadata and download</a></div></div><hr>';
+    let html = '<div class="row"><div class="col-md-3">Source</div><div class="col-md-9"><a style="color: #000000" href="' + cswRecord.recordInfoUrl + '" target="_blank">Full Metadata and Download</a></div></div><hr>';
     html += '<div class="row"><div class="col-md-3">Title</div><div class="col-md-9">' + cswRecord.name + '</div></div><hr>';
     html += '<div class="row"><div class="col-md-3">Abstract</div><div class="col-md-8"><div class="row" style="height: 100px;overflow-y: scroll;margin-left:0">' +
       cswRecord.description + '</div></div></div><hr>';

--- a/src/app/menupanel/activelayers/activelayerspanel.component.html
+++ b/src/app/menupanel/activelayers/activelayerspanel.component.html
@@ -27,9 +27,9 @@
                     <input matSliderThumb
                         [(ngModel)]="getUILayerModel(layer.id).opacity">
                 </mat-slider>
-                <div style="display: flex;" *ngIf="hasLegend(layer)">
+                <div style="display: flex;">
                     <!-- Display legend button -->
-                    <button class="btn btn-primary btn-sm legend" [disabled]="isLegendShown(layer.id)" (click)="showLegend(layer)">Legend</button>
+                    <button class="btn btn-primary btn-sm legend" *ngIf="hasLegend(layer)" [disabled]="isLegendShown(layer.id)" (click)="showLegend(layer)">Legend</button>
                     <!-- Display status button -->
                     <button class="btn btn-primary btn-sm status" (click)="openStatusReport(getUILayerModel(layer.id)); $event.stopPropagation();">Status</button>
                     <!-- Display info button -->


### PR DESCRIPTION
AUS-4409: Fixed issue of Info button not appearing in Active Layers panel for CSW record layers (blue bbox only).
AUS-4410: Fixed issue of "Full Metadata and Download" links opening in same window.