### PR TITLE
AUS-90210 UI Nitpicks

### DIFF
--- a/src/app/browsepanel/browsepanel.component.scss
+++ b/src/app/browsepanel/browsepanel.component.scss
@@ -156,7 +156,11 @@
         color: whitesmoke; /* From AuScope style guide */
     }
 
-    .form-check-label {
-        margin-top: 1px;
+    .form-check {
+      margin-left: 1rem;
+      
+      .form-check-label {
+          margin-top: 1px;
+      }
     }
 }

--- a/src/app/modalwindow/querier/querier.modal.component.html
+++ b/src/app/modalwindow/querier/querier.modal.component.html
@@ -138,7 +138,7 @@
     <!-- Message if downloading -->
     @if (data.downloading) {
       <div class="message-tab">
-        Downloading feature information...<br>
+        Downloading feature information...<br><br>
         <i class="fa fa-spin fa-spinner"></i>
       </div>
     }


### PR DESCRIPTION
* Enforce gap between Browse menu "Stay Open" checkbox and group title.
* Add some space between loader and message when downloading feature info.